### PR TITLE
Refactor to add RSA-SHA1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: go
 sudo: false
 go:
-  - 1.5
-  - 1.5.3
-  - 1.6
+  - 1.5.4
+  - 1.6.1
   - tip
-before_install:
-  - go get github.com/golang/lint/golint
 install:
+  - go get github.com/golang/lint/golint
   - go get -v -t .
 script:
-  - go test -v .
-  - go vet ./...
-  - golint ./...
+  - ./test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: go
 sudo: false
 go:
-  - 1.3
-  - 1.4
   - 1.5
+  - 1.5.3
+  - 1.6
   - tip
 before_install:
-  - go get golang.org/x/tools/cmd/vet
   - go get github.com/golang/lint/golint
 install:
   - go get -v -t .

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,13 @@
 # OAuth1 Changelog
 
-## latest
+## v0.4.0 (2016-04-20)
 
-* Use the HMACSigner as the default signer. This is the same signing behavior as in previous versions.
-* Added a Signer field to the Config to allow custom Signer implementations.s
-* Added an RSASigner.
-* Added missing Authorization Header quotes around OAuth parameter values. Many providers allowed these quotes to be missing.
-* Internalized `Signer` (as `auther`) which created Authorization Headers
-    - `SetAccessTokenAuthHeader`, `SetRequestAuthHeader`, and `SetRequestTokenAuthHeader` are no longer exposed.
+* Add a Signer field to the Config to allow custom Signer implementations.
+* Use the HMACSigner by default. This provides the same signing behavior as in previous versions (HMAC-SHA1).
+* Add an RSASigner for "RSA-SHA1" OAuth1 Providers.
+* Add missing Authorization Header quotes around OAuth parameter values. Many providers allowed these quotes to be missing.
+* Change `Signer` to be a signer interface.
+* Remove the old Signer methods `SetAccessTokenAuthHeader`, `SetRequestAuthHeader`, and `SetRequestTokenAuthHeader`.
 
 ## v0.3.0 (2015-09-13)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## latest
 
+* Use the HMACSigner as the default signer. This is the same signing behavior as in previous versions.
+* Added a Signer field to the Config to allow custom Signer implementations.s
+* Added an RSASigner.
+* Added missing Authorization Header quotes around OAuth parameter values. Many providers allowed these quotes to be missing.
 * Internalized `Signer` (as `auther`) which created Authorization Headers
     - `SetAccessTokenAuthHeader`, `SetRequestAuthHeader`, and `SetRequestTokenAuthHeader` are no longer exposed.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # OAuth1 Changelog
 
+## latest
+
+* Internalized `Signer` (as `auther`) which created Authorization Headers
+    - `SetAccessTokenAuthHeader`, `SetRequestAuthHeader`, and `SetRequestTokenAuthHeader` are no longer exposed.
+
 ## v0.3.0 (2015-09-13)
 
 * Added `NoContext` which may be used in most cases.

--- a/auther.go
+++ b/auther.go
@@ -65,7 +65,10 @@ func (a *auther) setRequestTokenAuthHeader(req *http.Request) error {
 		return err
 	}
 	signatureBase := signatureBase(req, params)
-	signature := a.signer().Sign("", signatureBase)
+	signature, err := a.signer().Sign("", signatureBase)
+	if err != nil {
+		return err
+	}
 	oauthParams[oauthSignatureParam] = signature
 	req.Header.Set(authorizationHeaderParam, authHeaderValue(oauthParams))
 	return nil
@@ -82,7 +85,10 @@ func (a *auther) setAccessTokenAuthHeader(req *http.Request, requestToken, reque
 		return err
 	}
 	signatureBase := signatureBase(req, params)
-	signature := a.signer().Sign(requestSecret, signatureBase)
+	signature, err := a.signer().Sign(requestSecret, signatureBase)
+	if err != nil {
+		return err
+	}
 	oauthParams[oauthSignatureParam] = signature
 	req.Header.Set(authorizationHeaderParam, authHeaderValue(oauthParams))
 	return nil
@@ -98,7 +104,10 @@ func (a *auther) setRequestAuthHeader(req *http.Request, accessToken *Token) err
 		return err
 	}
 	signatureBase := signatureBase(req, params)
-	signature := a.signer().Sign(accessToken.TokenSecret, signatureBase)
+	signature, err := a.signer().Sign(accessToken.TokenSecret, signatureBase)
+	if err != nil {
+		return err
+	}
 	oauthParams[oauthSignatureParam] = signature
 	req.Header.Set(authorizationHeaderParam, authHeaderValue(oauthParams))
 	return nil
@@ -139,7 +148,7 @@ func (a *auther) signer() Signer {
 	if a.config.Signer != nil {
 		return a.config.Signer
 	}
-	return &HMACSigner{consumerSecret: a.config.ConsumerSecret}
+	return &HMACSigner{ConsumerSecret: a.config.ConsumerSecret}
 }
 
 // authHeaderValue formats OAuth parameters according to RFC 5849 3.5.1. OAuth

--- a/auther.go
+++ b/auther.go
@@ -40,17 +40,6 @@ type clock interface {
 	Now() time.Time
 }
 
-type realClock struct{}
-
-// newRealClock returns a clock which delegates calls to the time package.
-func newRealClock() clock {
-	return &realClock{}
-}
-
-func (c *realClock) Now() time.Time {
-	return time.Now()
-}
-
 // A noncer provides random nonce strings.
 type noncer interface {
 	Nonce() string
@@ -67,7 +56,6 @@ type auther struct {
 func newAuther(config *Config) *auther {
 	return &auther{
 		config: config,
-		clock:  newRealClock(),
 	}
 }
 
@@ -144,7 +132,10 @@ func (s *auther) nonce() string {
 
 // Returns the Unix epoch seconds.
 func (s *auther) epoch() int64 {
-	return s.clock.Now().Unix()
+	if s.clock != nil {
+		return s.clock.Now().Unix()
+	}
+	return time.Now().Unix()
 }
 
 // authHeaderValue formats OAuth parameters according to RFC 5849 3.5.1. OAuth

--- a/auther.go
+++ b/auther.go
@@ -157,7 +157,7 @@ func (a *auther) signer() Signer {
 // string.
 // The given OAuth params should include the "oauth_signature" key.
 func authHeaderValue(oauthParams map[string]string) string {
-	pairs := sortParameters(encodeParameters(oauthParams))
+	pairs := sortParameters(encodeParameters(oauthParams), `%s="%s"`)
 	return authorizationPrefix + strings.Join(pairs, ", ")
 }
 
@@ -171,9 +171,9 @@ func encodeParameters(params map[string]string) map[string]string {
 	return encoded
 }
 
-// sortParameters sorts parameters by key and returns a slice of key=value
-// pair strings.
-func sortParameters(params map[string]string) []string {
+// sortParameters sorts parameters by key and returns a slice of key/value
+// pairs formatted with the given format string (e.g. "%s=%s").
+func sortParameters(params map[string]string, format string) []string {
 	// sort by key
 	keys := make([]string, len(params))
 	i := 0
@@ -185,7 +185,7 @@ func sortParameters(params map[string]string) []string {
 	// parameter join
 	pairs := make([]string, len(params))
 	for i, key := range keys {
-		pairs[i] = fmt.Sprintf("%s=%s", key, params[key])
+		pairs[i] = fmt.Sprintf(format, key, params[key])
 	}
 	return pairs
 }
@@ -261,5 +261,5 @@ func baseURI(req *http.Request) string {
 // The parameters are encoded, sorted by key, keys and values joined with "&",
 // and pairs joined with "=" (e.g. foo=bar&q=gopher).
 func normalizedParameterString(params map[string]string) string {
-	return strings.Join(sortParameters(encodeParameters(params)), "&")
+	return strings.Join(sortParameters(encodeParameters(params), "%s=%s"), "&")
 }

--- a/auther_test.go
+++ b/auther_test.go
@@ -49,7 +49,8 @@ func TestSigner_Default(t *testing.T) {
 	expectedSignature := "BE0uILOruKfSXd4UzYlLJDfOq08="
 	// assert that the default signer produces the expected HMAC-SHA1 digest
 	method := a.signer().Name()
-	digest := a.signer().Sign("token_secret", "hello world")
+	digest, err := a.signer().Sign("token_secret", "hello world")
+	assert.Nil(t, err)
 	assert.Equal(t, "HMAC-SHA1", method)
 	assert.Equal(t, expectedSignature, digest)
 }
@@ -59,8 +60,9 @@ type identitySigner struct{}
 func (s *identitySigner) Name() string {
 	return "identity"
 }
-func (s *identitySigner) Sign(tokenSecret, message string) string {
-	return message
+
+func (s *identitySigner) Sign(tokenSecret, message string) (string, error) {
+	return message, nil
 }
 
 func TestSigner_Custom(t *testing.T) {
@@ -71,7 +73,8 @@ func TestSigner_Custom(t *testing.T) {
 	a := newAuther(config)
 	// assert that the custom signer is used
 	method := a.signer().Name()
-	digest := a.signer().Sign("secret", "hello world")
+	digest, err := a.signer().Sign("secret", "hello world")
+	assert.Nil(t, err)
 	assert.Equal(t, "identity", method)
 	assert.Equal(t, "hello world", digest)
 }

--- a/auther_test.go
+++ b/auther_test.go
@@ -85,10 +85,10 @@ func TestAuthHeaderValue(t *testing.T) {
 		authHeader string
 	}{
 		{map[string]string{}, "OAuth "},
-		{map[string]string{"a": "b"}, "OAuth a=b"},
-		{map[string]string{"a": "b", "c": "d", "e": "f", "1": "2"}, "OAuth 1=2, a=b, c=d, e=f"},
-		{map[string]string{"/= +doencode": "/= +doencode"}, "OAuth %2F%3D%20%2Bdoencode=%2F%3D%20%2Bdoencode"},
-		{map[string]string{"-._~dontencode": "-._~dontencode"}, "OAuth -._~dontencode=-._~dontencode"},
+		{map[string]string{"a": "b"}, `OAuth a="b"`},
+		{map[string]string{"a": "b", "c": "d", "e": "f", "1": "2"}, `OAuth 1="2", a="b", c="d", e="f"`},
+		{map[string]string{"/= +doencode": "/= +doencode"}, `OAuth %2F%3D%20%2Bdoencode="%2F%3D%20%2Bdoencode"`},
+		{map[string]string{"-._~dontencode": "-._~dontencode"}, `OAuth -._~dontencode="-._~dontencode"`},
 	}
 	for _, c := range cases {
 		assert.Equal(t, c.authHeader, authHeaderValue(c.params))
@@ -127,7 +127,7 @@ func TestSortParameters(t *testing.T) {
 		"dup=fox",
 		"rsa=cat",
 	}
-	assert.Equal(t, expected, sortParameters(input))
+	assert.Equal(t, expected, sortParameters(input, "%s=%s"))
 }
 
 func TestCollectParameters(t *testing.T) {

--- a/auther_test.go
+++ b/auther_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestCommonOAuthParams(t *testing.T) {
 	config := &Config{ConsumerKey: "some_consumer_key"}
-	signer := &Signer{config, &fixedClock{time.Unix(50037133, 0)}, &fixedNoncer{"some_nonce"}}
+	auther := &auther{config, &fixedClock{time.Unix(50037133, 0)}, &fixedNoncer{"some_nonce"}}
 	expectedParams := map[string]string{
 		"oauth_consumer_key":     "some_consumer_key",
 		"oauth_signature_method": "HMAC-SHA1",
@@ -20,25 +20,17 @@ func TestCommonOAuthParams(t *testing.T) {
 		"oauth_nonce":            "some_nonce",
 		"oauth_version":          "1.0",
 	}
-	assert.Equal(t, expectedParams, signer.commonOAuthParams())
+	assert.Equal(t, expectedParams, auther.commonOAuthParams())
 }
 
 func TestNonce(t *testing.T) {
-	signer := &Signer{}
-	nonce := signer.nonce()
+	auther := &auther{}
+	nonce := auther.nonce()
 	// assert that 32 bytes (256 bites) become 44 bytes since a base64 byte
 	// zeros the 2 high bits. 3 bytes convert to 4 base64 bytes, 40 base64 bytes
 	// represent the first 30 of 32 bytes, = padding adds another 4 byte group.
 	// base64 bytes = 4 * floor(bytes/3) + 4
 	assert.Equal(t, 44, len([]byte(nonce)))
-}
-
-func TestSetAuthorizationHeader(t *testing.T) {
-	expectedHeaderValue := "test_authorization_string"
-	req, err := http.NewRequest("GET", "/", nil)
-	assert.Nil(t, err)
-	setAuthorizationHeader(req, expectedHeaderValue)
-	assert.Equal(t, req.Header.Get("Authorization"), expectedHeaderValue)
 }
 
 func TestAuthHeaderValue(t *testing.T) {

--- a/auther_test.go
+++ b/auther_test.go
@@ -33,6 +33,15 @@ func TestNonce(t *testing.T) {
 	assert.Equal(t, 44, len([]byte(nonce)))
 }
 
+func TestEpoch(t *testing.T) {
+	a := &auther{}
+	// assert that a real time is used by default
+	assert.InEpsilon(t, time.Now().Unix(), a.epoch(), 1)
+	// assert that the fixed clock can be used for testing
+	a = &auther{clock: &fixedClock{time.Unix(50037133, 0)}}
+	assert.Equal(t, int64(50037133), a.epoch())
+}
+
 func TestAuthHeaderValue(t *testing.T) {
 	cases := []struct {
 		params     map[string]string
@@ -204,13 +213,4 @@ func TestSignature(t *testing.T) {
 	// echo -n "hello world" | openssl dgst -sha1 -hmac "consumer_secret&token_secret" -binary | base64
 	expectedSignature := "BE0uILOruKfSXd4UzYlLJDfOq08="
 	assert.Equal(t, expectedSignature, signature(consumerSecret, tokenSecret, message))
-}
-
-func TestNewRealClock(t *testing.T) {
-	// assert that realClock implements the clock interface
-	var _ clock = (*realClock)(nil)                     // compilation assertion
-	assert.Implements(t, (*clock)(nil), newRealClock()) // not truly needed
-	// assert that realClock returns a sane current time
-	rk := newRealClock()
-	assert.InEpsilon(t, time.Now().Unix(), rk.Now().Unix(), 1)
 }

--- a/config.go
+++ b/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	CallbackURL string
 	// Provider Endpoint specifying OAuth1 endpoint URLs
 	Endpoint Endpoint
+	// OAuth1 Signer (defaults to HMAC-SHA1)
+	Signer Signer
 }
 
 // NewConfig returns a new Config with the given consumer key and secret.

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ Use the access `Token` to make requests on behalf of a Twitter user.
     export TWITTER_CONSUMER_KEY=xxx
     export TWITTER_CONSUMER_SECRET=xxx
     export TWITTER_ACCESS_TOKEN=xxx
-    export TWITTER_ACCESS_TOKEN_SECRET=xxx
+    export TWITTER_ACCESS_SECRET=xxx
     go run twitter-request.go
 
 
@@ -41,7 +41,7 @@ Use the access `Token` to make requests on behalf of a Tumblr user.
     export TUMBLR_CONSUMER_KEY=xxx
     export TUMBLR_CONSUMER_SECRET=xxx
     export TUMBLR_ACCESS_TOKEN=xxx
-    export TUMBLR_ACCESS_TOKEN_SECRET=xxx
+    export TUMBLR_ACCESS_SECRET=xxx
     go run tumblr-request.go
 
 Note that only some Tumblr endpoints require OAuth1 signed requests, other endpoints require a special consumer key query parameter or no authorization.

--- a/examples/tumblr-request.go
+++ b/examples/tumblr-request.go
@@ -14,13 +14,13 @@ func main() {
 	consumerKey := os.Getenv("TUMBLR_CONSUMER_KEY")
 	consumerSecret := os.Getenv("TUMBLR_CONSUMER_SECRET")
 	accessToken := os.Getenv("TUMBLR_ACCESS_TOKEN")
-	accessTokenSecret := os.Getenv("TUMBLR_ACCESS_TOKEN_SECRET")
-	if consumerKey == "" || consumerSecret == "" || accessToken == "" || accessTokenSecret == "" {
+	accessSecret := os.Getenv("TUMBLR_ACCESS_SECRET")
+	if consumerKey == "" || consumerSecret == "" || accessToken == "" || accessSecret == "" {
 		panic("Missing required environment variable")
 	}
 
 	config := oauth1.NewConfig(consumerKey, consumerSecret)
-	token := oauth1.NewToken(accessToken, accessTokenSecret)
+	token := oauth1.NewToken(accessToken, accessSecret)
 
 	// httpClient will automatically authorize http.Request's
 	httpClient := config.Client(oauth1.NoContext, token)

--- a/examples/twitter-request.go
+++ b/examples/twitter-request.go
@@ -15,13 +15,13 @@ func main() {
 	consumerKey := os.Getenv("TWITTER_CONSUMER_KEY")
 	consumerSecret := os.Getenv("TWITTER_CONSUMER_SECRET")
 	accessToken := os.Getenv("TWITTER_ACCESS_TOKEN")
-	accessTokenSecret := os.Getenv("TWITTER_ACCESS_TOKEN_SECRET")
-	if consumerKey == "" || consumerSecret == "" || accessToken == "" || accessTokenSecret == "" {
+	accessSecret := os.Getenv("TWITTER_ACCESS_SECRET")
+	if consumerKey == "" || consumerSecret == "" || accessToken == "" || accessSecret == "" {
 		panic("Missing required environment variable")
 	}
 
 	config := oauth1.NewConfig(consumerKey, consumerSecret)
-	token := oauth1.NewToken(accessToken, accessTokenSecret)
+	token := oauth1.NewToken(accessToken, accessSecret)
 
 	// httpClient will automatically authorize http.Request's
 	httpClient := config.Client(oauth1.NoContext, token)

--- a/reference_test.go
+++ b/reference_test.go
@@ -180,7 +180,7 @@ func parseOAuthParamsOrFail(t *testing.T, authHeader string) map[string]string {
 		if len(pair) != 2 {
 			assert.Fail(t, "Error parsing OAuth parameter %s", pairStr)
 		}
-		params[pair[0]] = pair[1]
+		params[pair[0]] = strings.Replace(pair[1], "\"", "", -1)
 	}
 	return params
 }

--- a/signer.go
+++ b/signer.go
@@ -53,10 +53,8 @@ func (s *RSASigner) Name() string {
 // Sign uses RSA PKCS1-v1_5 to sign a SHA1 digest of the given message. The
 // tokenSecret is not used with this signing scheme.
 func (s *RSASigner) Sign(tokenSecret, message string) (string, error) {
-	h := sha1.New()
-	h.Write([]byte(message))
-	digest := h.Sum(nil)
-	signature, err := rsa.SignPKCS1v15(rand.Reader, s.PrivateKey, crypto.SHA1, digest)
+	digest := sha1.Sum([]byte(message))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, s.PrivateKey, crypto.SHA1, digest[:])
 	if err != nil {
 		return "", err
 	}

--- a/signer.go
+++ b/signer.go
@@ -1,7 +1,10 @@
 package oauth1
 
 import (
+	"crypto"
 	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha1"
 	"encoding/base64"
 	"strings"
@@ -12,13 +15,13 @@ type Signer interface {
 	// Name returns the name of the signing method.
 	Name() string
 	// Sign signs the message using the given secret key.
-	Sign(key string, message string) string
+	Sign(key string, message string) (string, error)
 }
 
 // HMACSigner signs messages with an HMAC SHA1 digest, using the concatenated
 // consumer secret and token secret as the key.
 type HMACSigner struct {
-	consumerSecret string
+	ConsumerSecret string
 }
 
 // Name returns the HMAC-SHA1 method.
@@ -28,10 +31,34 @@ func (s *HMACSigner) Name() string {
 
 // Sign creates a concatenated consumer and token secret key and calculates
 // the HMAC digest of the message. Returns the base64 encoded digest bytes.
-func (s *HMACSigner) Sign(tokenSecret, message string) string {
-	signingKey := strings.Join([]string{s.consumerSecret, tokenSecret}, "&")
+func (s *HMACSigner) Sign(tokenSecret, message string) (string, error) {
+	signingKey := strings.Join([]string{s.ConsumerSecret, tokenSecret}, "&")
 	mac := hmac.New(sha1.New, []byte(signingKey))
 	mac.Write([]byte(message))
 	signatureBytes := mac.Sum(nil)
-	return base64.StdEncoding.EncodeToString(signatureBytes)
+	return base64.StdEncoding.EncodeToString(signatureBytes), nil
+}
+
+// RSASigner RSA PKCS1-v1_5 signs SHA1 digests of messages using the given
+// RSA private key.
+type RSASigner struct {
+	PrivateKey *rsa.PrivateKey
+}
+
+// Name returns the RSA-SHA1 method.
+func (s *RSASigner) Name() string {
+	return "RSA-SHA1"
+}
+
+// Sign uses RSA PKCS1-v1_5 to sign a SHA1 digest of the given message. The
+// tokenSecret is not used with this signing scheme.
+func (s *RSASigner) Sign(tokenSecret, message string) (string, error) {
+	h := sha1.New()
+	h.Write([]byte(message))
+	digest := h.Sum(nil)
+	signature, err := rsa.SignPKCS1v15(rand.Reader, s.PrivateKey, crypto.SHA1, digest)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(signature), nil
 }

--- a/signer.go
+++ b/signer.go
@@ -1,0 +1,37 @@
+package oauth1
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"strings"
+)
+
+// A Signer signs messages to create signed OAuth1 Requests.
+type Signer interface {
+	// Name returns the name of the signing method.
+	Name() string
+	// Sign signs the message using the given secret key.
+	Sign(key string, message string) string
+}
+
+// HMACSigner signs messages with an HMAC SHA1 digest, using the concatenated
+// consumer secret and token secret as the key.
+type HMACSigner struct {
+	consumerSecret string
+}
+
+// Name returns the HMAC-SHA1 method.
+func (s *HMACSigner) Name() string {
+	return "HMAC-SHA1"
+}
+
+// Sign creates a concatenated consumer and token secret key and calculates
+// the HMAC digest of the message. Returns the base64 encoded digest bytes.
+func (s *HMACSigner) Sign(tokenSecret, message string) string {
+	signingKey := strings.Join([]string{s.consumerSecret, tokenSecret}, "&")
+	mac := hmac.New(sha1.New, []byte(signingKey))
+	mac.Write([]byte(message))
+	signatureBytes := mac.Sum(nil)
+	return base64.StdEncoding.EncodeToString(signatureBytes)
+}

--- a/test
+++ b/test
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+go test . -cover
+go vet ./...
+
+echo "Checking gofmt..."
+FORMATTABLE="$(find . -type f -name '*.go')"
+fmtRes=$(gofmt -l $FORMATTABLE)
+if [ -n "${fmtRes}" ]; then
+  echo -e "gofmt checking failed:\n${fmtRes}"
+  exit 2
+fi
+
+echo "Checking golint..."
+lintRes=$(go list ./... | xargs -n 1 golint)
+if [ -n "${lintRes}" ]; then
+  echo -e "golint checking failed:\n${lintRes}"
+  exit 2
+fi

--- a/transport.go
+++ b/transport.go
@@ -6,8 +6,8 @@ import (
 )
 
 // Transport is an http.RoundTripper which makes OAuth1 HTTP requests. It
-// wraps a base RoundTripper and adds an Authorization header using an
-// OAuth1 signer and TokenSource.
+// wraps a base RoundTripper and adds an Authorization header using the
+// token from a TokenSource.
 //
 // Transport is a low-level component, most users should use Config to create
 // an http.Client instead.
@@ -17,12 +17,12 @@ type Transport struct {
 	Base http.RoundTripper
 	// source supplies the token to use when signing a request
 	source TokenSource
-	// signer is a configured OAuth 1 Signer
-	signer *Signer
+	// auther adds OAuth1 Authorization headers to requests
+	auther *auther
 }
 
-// RoundTrip authorizes the request with a signed OAuth1 authorization header
-// using the transport token source and signer.
+// RoundTrip authorizes the request with a signed OAuth1 Authorization header
+// using the auther and TokenSource.
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.source == nil {
 		return nil, fmt.Errorf("oauth1: Transport's source is nil")
@@ -31,12 +31,12 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	if t.signer == nil {
-		return nil, fmt.Errorf("oauth1: Transport's signer is nil")
+	if t.auther == nil {
+		return nil, fmt.Errorf("oauth1: Transport's auther is nil")
 	}
 	// RoundTripper should not modify the given request, clone it
 	req2 := cloneRequest(req)
-	err = t.signer.SetRequestAuthHeader(req2, accessToken)
+	err = t.auther.setRequestAuthHeader(req2, accessToken)
 	if err != nil {
 		return nil, err
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -11,17 +11,18 @@ import (
 
 func TestTransport(t *testing.T) {
 	const (
-		expectedToken       = "access_token"
-		expectedConsumerKey = "consumer_key"
-		expectedNonce       = "some_nonce"
-		expectedTimestamp   = "123456789"
+		expectedToken           = "access_token"
+		expectedConsumerKey     = "consumer_key"
+		expectedNonce           = "some_nonce"
+		expectedSignatureMethod = "HMAC-SHA1"
+		expectedTimestamp       = "123456789"
 	)
 	server := newMockServer(func(w http.ResponseWriter, req *http.Request) {
 		params := parseOAuthParamsOrFail(t, req.Header.Get("Authorization"))
 		assert.Equal(t, expectedToken, params[oauthTokenParam])
 		assert.Equal(t, expectedConsumerKey, params[oauthConsumerKeyParam])
 		assert.Equal(t, expectedNonce, params[oauthNonceParam])
-		assert.Equal(t, defaultSignatureMethod, params[oauthSignatureMethodParam])
+		assert.Equal(t, expectedSignatureMethod, params[oauthSignatureMethodParam])
 		assert.Equal(t, expectedTimestamp, params[oauthTimestampParam])
 		assert.Equal(t, defaultOauthVersion, params[oauthVersionParam])
 		// oauth_signature will vary, httptest.Server uses a random port

--- a/transport_test.go
+++ b/transport_test.go
@@ -32,14 +32,14 @@ func TestTransport(t *testing.T) {
 		ConsumerKey:    expectedConsumerKey,
 		ConsumerSecret: "consumer_secret",
 	}
-	signer := &Signer{
+	auther := &auther{
 		config: config,
 		clock:  &fixedClock{time.Unix(123456789, 0)},
 		noncer: &fixedNoncer{expectedNonce},
 	}
 	tr := &Transport{
 		source: StaticTokenSource(NewToken(expectedToken, "some_secret")),
-		signer: signer,
+		auther: auther,
 	}
 	client := &http.Client{Transport: tr}
 
@@ -67,7 +67,7 @@ func TestTransport_customBaseTransport(t *testing.T) {
 func TestTransport_nilSource(t *testing.T) {
 	tr := &Transport{
 		source: nil,
-		signer: &Signer{
+		auther: &auther{
 			config: &Config{},
 			clock:  &fixedClock{time.Unix(123456789, 0)},
 			noncer: &fixedNoncer{"any_nonce"},
@@ -84,7 +84,7 @@ func TestTransport_nilSource(t *testing.T) {
 func TestTransport_emptySource(t *testing.T) {
 	tr := &Transport{
 		source: StaticTokenSource(nil),
-		signer: &Signer{
+		auther: &auther{
 			config: &Config{},
 			clock:  &fixedClock{time.Unix(123456789, 0)},
 			noncer: &fixedNoncer{"any_nonce"},
@@ -98,16 +98,16 @@ func TestTransport_emptySource(t *testing.T) {
 	}
 }
 
-func TestTransport_nilSigner(t *testing.T) {
+func TestTransport_nilAuther(t *testing.T) {
 	tr := &Transport{
 		source: StaticTokenSource(&Token{}),
-		signer: nil,
+		auther: nil,
 	}
 	client := &http.Client{Transport: tr}
 	resp, err := client.Get("http://example.com")
 	assert.Nil(t, resp)
 	if assert.Error(t, err) {
-		assert.Equal(t, "Get http://example.com: oauth1: Transport's signer is nil", err.Error())
+		assert.Equal(t, "Get http://example.com: oauth1: Transport's auther is nil", err.Error())
 	}
 }
 


### PR DESCRIPTION
Authorization Header marshaling and signing have been split to allow `Config`'s to use custom `Signer`'s if desired. If no `Signer` is specified in the `Config`, the HMACSigner will be used to produce HMAC-SHA1 digest signatures, which is the same behavior as before (for Twitter, Digits, and Tumblr).

The `RSA-SHA1` signer hasn't been verified with a provider. Atlassian's UX makes it unclear how to use their products. I *think* if one were to pay money for JIRA and had admin abilities you could upload your organization/app's public RSA key to get this to work.

Perhaps something like:

```
endpoint := oauth1.Endpoint{
    RequestTokenURL: "https://mycompany.atlassian.net/plugins/servlet/oauth/request-token",
    AuthorizeURL: "https://mycompany.atlassian.net/plugins/servlet/oauth/authorize",
    AccessTokenURL: "https://mycompany.atlassian.net/plugins/servlet/oauth/access-token"
}
config := &oauth1.Config{
    ConsumerKey: "JIRAConsumerKey",
    CallbackURL:  "http://localhost:8080/callback",
    Endpoint:     endpoint,
    Signer:       &RSASigner{PrivateKey: rsaPrivateKeyFromFile}
}
```

Exposed Signer methods have been removed which is a breaking change. I don't expect upsteam users to be affected by this. API clients and Login packages use the `Config` and `http.Client`'s it produces.

Relevant to #5 