### PR TITLE
Fix: Token existence check should be first

### DIFF
--- a/config.go
+++ b/config.go
@@ -82,13 +82,13 @@ func (c *Config) RequestToken() (requestToken, requestSecret string, err error) 
 	if err != nil {
 		return "", "", err
 	}
-	if values.Get(oauthCallbackConfirmedParam) != "true" {
-		return "", "", errors.New("oauth1: oauth_callback_confirmed was not true")
-	}
 	requestToken = values.Get(oauthTokenParam)
 	requestSecret = values.Get(oauthTokenSecretParam)
 	if requestToken == "" || requestSecret == "" {
 		return "", "", errors.New("oauth1: Response missing oauth_token or oauth_token_secret")
+	}
+	if values.Get(oauthCallbackConfirmedParam) != "true" {
+		return "", "", errors.New("oauth1: oauth_callback_confirmed was not true")
 	}
 	return requestToken, requestSecret, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -124,7 +124,11 @@ func TestConfigRequestToken_InvalidRequestTokenURL(t *testing.T) {
 }
 
 func TestConfigRequestToken_CallbackNotConfirmed(t *testing.T) {
+	const expectedToken = "reqest_token"
+	const expectedSecret = "request_secret"
 	data := url.Values{}
+	data.Add("oauth_token", expectedToken)
+	data.Add("oauth_token_secret", expectedSecret)
 	data.Add("oauth_callback_confirmed", "false")
 	server := newRequestTokenServer(t, data)
 	defer server.Close()


### PR DESCRIPTION
RequestToken() returns `oauth_callback_confirmed was not true` error even though the server returned error and did not include the token into the response. This inaccurate message confuses developers so the error check precedence should be swapped.