### PR TITLE
Dynamic Endpoint.AuthorizeURL

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ import (
 const (
 	oauthTokenSecretParam       = "oauth_token_secret"
 	oauthCallbackConfirmedParam = "oauth_callback_confirmed"
+	oauthLoginURL               = "login_url"
 )
 
 // Config represents an OAuth1 consumer's (client's) key and secret, the
@@ -86,6 +87,7 @@ func (c *Config) RequestToken() (requestToken, requestSecret string, err error) 
 	if err != nil {
 		return "", "", err
 	}
+	c.Endpoint.AuthorizeURL = values.Get(oauthLoginURL)
 	requestToken = values.Get(oauthTokenParam)
 	requestSecret = values.Get(oauthTokenSecretParam)
 	if requestToken == "" || requestSecret == "" {

--- a/etsy/etsy.go
+++ b/etsy/etsy.go
@@ -1,0 +1,11 @@
+// Package etsy provides constants for using OAuth1 to access Etsy.
+package etsy
+
+import "github.com/dghubble/oauth1"
+
+// Endpoint is Etsy's OAuth 1 endpoint.
+var Endpoint = oauth1.Endpoint{
+	RequestTokenURL: "https://openapi.etsy.com/v2/oauth/request_token?scope=transactions_r",
+	// AuthorizeURL:    "https://api.xing.com/v1/authorize",
+	AccessTokenURL: "https://openapi.etsy.com/v2/oauth/access_token",
+}


### PR DESCRIPTION
The authorisation URL is sometimes provided in the response of the request token endpoint.
This PR allows for the `AuthorizeURL` to be set from that response.

It allows for the following scenario:
```go
func main() {
	var EtsyEndpoints = oauth1.Endpoint{
		RequestTokenURL: "https://openapi.etsy.com/v2/oauth/request_token?scope=email_r",
		//AuthorizeURL:    "https://api.twitter.com/oauth/authenticate",
		AccessTokenURL: "https://openapi.etsy.com/v2/oauth/access_token",
	}
  [...]
	fmt.Println("Consumer was granted an access token to act on behalf of a user.")
	fmt.Printf("token: %s\nsecret: %s\n", accessToken.Token, accessToken.TokenSecret)
}

func login() (requestToken, requestSecret string, err error) {
	requestToken, requestSecret, err = config.RequestToken()
	if err != nil {
		return "", "", err
	}
	/*authorizationURL, err := config.AuthorizationURL(requestToken)
	if err != nil {
		return "", "", err
	}*/
	fmt.Printf("Open this URL in your browser:\n%s\n", config.Endpoint.AuthorizeURL)
	return requestToken, requestSecret, err
}
```