### PR TITLE
fixed response code handling

### DIFF
--- a/config.go
+++ b/config.go
@@ -74,7 +74,7 @@ func (c *Config) RequestToken() (requestToken, requestSecret string, err error) 
 	}
 	// when err is nil, resp contains a non-nil resp.Body which must be closed
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return "", "", fmt.Errorf("oauth1: Server returned status %d", resp.StatusCode)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
@@ -151,7 +151,7 @@ func (c *Config) AccessToken(requestToken, requestSecret, verifier string) (acce
 	}
 	// when err is nil, resp contains a non-nil resp.Body which must be closed
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return "", "", fmt.Errorf("oauth1: Server returned status %d", resp.StatusCode)
 	}
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Hey @dghubble ,

thanks for merging the other PR #10. This one adds two checks for http status code 201, which is used by Xing OAUTH1 Api introduced in #10. Would be cool if we could get this one in soon.

We could actually think about allowing some more, but I guess these can also be added when some different APIs require them, yah?

Thanks and greetings from Germany!
Alex