### PR TITLE
doc,README: use oauth1.NewToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ config := oauth1.Config{
     ```go
     accessToken, accessSecret, err := config.AccessToken(requestToken, requestSecret, verifier)
     // handle error
-    token := NewToken(accessToken, accessSecret)
+    token := oauth1.NewToken(accessToken, accessSecret)
     ```
 
 Check the [examples](examples) to see this authorization flow in action from the command line, with Twitter PIN-based login and Tumblr login.

--- a/doc.go
+++ b/doc.go
@@ -64,7 +64,7 @@ to make requests on behalf of the user.
 
 	accessToken, accessSecret, err := config.AccessToken(requestToken, requestSecret, verifier)
 	// handle error
-	token := NewToken(accessToken, accessSecret)
+	token := oauth1.NewToken(accessToken, accessSecret)
 
 Check the examples to see this authorization flow in action from the command
 line, with Twitter PIN-based login and Tumblr login.


### PR DESCRIPTION
Just a minor typo in which the example
out of pattern and used NewToken instead of oauth1.NewToken
as the examples assume that the user is building in their own
package outside of oauth1.