### PR TITLE
Add config option for custom HTTP client

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -56,6 +56,17 @@ func TestNewClient_ContextClientTransport(t *testing.T) {
 	assert.Equal(t, baseTransport, transport.base())
 }
 
+func TestClientWithBaseTransport(t *testing.T) {
+	baseTransport := &http.Transport{}
+	baseClient := &http.Client{Transport: baseTransport}
+	config := &Config{ConsumerKey: "t", ConsumerSecret: "s", HTTPClient: baseClient}
+	client := config.ClientWithBaseTransport(NewToken("t", "s"))
+	// assert that the client uses the config's client's Transport as its base RoundTripper
+	transport, ok := client.Transport.(*Transport)
+	assert.True(t, ok)
+	assert.Equal(t, baseTransport, transport.base())
+}
+
 // newRequestTokenServer returns a new httptest.Server for an OAuth1 provider
 // request token endpoint.
 func newRequestTokenServer(t *testing.T, data url.Values) *httptest.Server {


### PR DESCRIPTION
Hi @dghubble, thanks for creating this `oath1` library! :clap:

I'm using this library on Google App Engine, which requires a [custom HTTP client for all outbound requests](https://cloud.google.com/appengine/docs/standard/go/issue-requests), and this PR is to add _extra_ support for this use case.

For authenticated requests (using access token and secret), the existing functionality works perfectly. You can use `NewClient` and a `context.Context` to register the base HTTP transport, or you can set the base HTTP transport directly via the `Transport.Base` field.

But if you're in the Google App Engine environment and you need to implement the full authentication process (requesting tokens and converting them to accessing tokens), then you need to use a custom HTTP client for those HTTP requests too.

Here's a summary of the changes I've implemented:

1. I've added a config option for a custom HTTP client.
2. This HTTP client is used for `RequestToken` and `AccessToken` HTTP requests to the endpoint.
3. The new config option can also be used directly for constructing new Client objects, instead of using a context parameter.
5. To preserve backwards-compatibility, I did not modify the existing API.

I've tried to follow the [Contributing Guide](https://gist.github.com/dghubble/be682c123727f70bcfe7), but let me know if there are any issues or if any changes are needed.