### PR TITLE
Add option to bypass callback confirm check for non-complying APIs

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	Endpoint Endpoint
 	// OAuth1 Signer (defaults to HMAC-SHA1)
 	Signer Signer
+	// Disable endpoint callback url validation check
+	DisableCallbackConfirm bool
 }
 
 // NewConfig returns a new Config with the given consumer key and secret.
@@ -91,7 +93,7 @@ func (c *Config) RequestToken() (requestToken, requestSecret string, err error) 
 	if requestToken == "" || requestSecret == "" {
 		return "", "", errors.New("oauth1: Response missing oauth_token or oauth_token_secret")
 	}
-	if values.Get(oauthCallbackConfirmedParam) != "true" {
+	if !c.DisableCallbackConfirm && values.Get(oauthCallbackConfirmedParam) != "true" {
 		return "", "", errors.New("oauth1: oauth_callback_confirmed was not true")
 	}
 	return requestToken, requestSecret, nil


### PR DESCRIPTION
Hey there, thanks for making a super useful package!

Added a configuration field `DisableCallbackConfirm` to ignore the `oauth_callback_confirmed` check for APIs that don't return it :-/

Default behaviour is maintained, and it's a *disable* flag so the default field value of `false` should be safe.

An alternative (if you would prefer) is to only fail the oauthCallbackConfirmedParam check if it's present in the response, but that would change current behaviour and be less explicit imo.