### PR TITLE
Add support for the realm parameter

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	CallbackURL string
 	// Provider Endpoint specifying OAuth1 endpoint URLs
 	Endpoint Endpoint
+	// Realm of authorization
+	Realm string
 	// OAuth1 Signer (defaults to HMAC-SHA1)
 	Signer Signer
 }


### PR DESCRIPTION
## What was changed?
Add support for specifying `realm` in the `Authorization` header. The realm parameter should be included in the `Authorization` header along with the other `oauth_*` parameters, but must not be included in the base string used to generate the `oauth_signature` parameter. To achieve this, `realm` has been added (if populated) to the common OAuth params and the `collectParameters` function has been updated to exclude the parameter. I believe this implementation most closely matches how [the spec](https://tools.ietf.org/html/rfc5849#section-3.4.1.3.1) describes parameter collection.

## How was this tested?
- This change was tested in an application that makes requests to Netsuite using one-legged OAuth1.0a. Netsuite requires the `realm` parameter for successful authentication.
- A new test case was added to assert that the `realm` parameter was only included in `commonOAuthParams()` when it had a value.
- The existing test case `TestCollectParameters` was updated to have the config's `Realm` set and asserts that it is excluded from the resulting parameter list.
- `go test` passed all tests (see travis build).