### PR TITLE
Make noncer configurable via config

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	Realm string
 	// OAuth1 Signer (defaults to HMAC-SHA1)
 	Signer Signer
+	// OAuth1 Noncer (returns a base64 encoded random 32 byte string by default)
+	Noncer Noncer
 }
 
 // NewConfig returns a new Config with the given consumer key and secret.

--- a/noncer.go
+++ b/noncer.go
@@ -1,0 +1,24 @@
+package oauth1
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+)
+
+// A Noncer generates random string.
+type Noncer interface {
+	// returns random string
+	Nonce() string
+}
+
+// DefaultNoncer generates base64 encoded random string.
+type DefaultNoncer struct {
+	nonce string
+}
+
+// Nonce returns a base64 encoded random 32 byte string.
+func (s *DefaultNoncer) Nonce() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return base64.StdEncoding.EncodeToString(b)
+}

--- a/reference_test.go
+++ b/reference_test.go
@@ -33,9 +33,10 @@ func TestTwitterRequestTokenAuthHeader(t *testing.T) {
 			AuthorizeURL:    "https://api.twitter.com/oauth/authorize",
 			AccessTokenURL:  "https://api.twitter.com/oauth/access_token",
 		},
+		Noncer: &identityNoncer{expectedNonce},
 	}
 
-	auther := &auther{config, &fixedClock{time.Unix(unixTimestamp, 0)}, &fixedNoncer{expectedNonce}}
+	auther := &auther{config, &fixedClock{time.Unix(unixTimestamp, 0)}}
 	req, err := http.NewRequest("POST", config.Endpoint.RequestTokenURL, nil)
 	assert.Nil(t, err)
 	err = auther.setRequestTokenAuthHeader(req)
@@ -70,9 +71,10 @@ func TestTwitterAccessTokenAuthHeader(t *testing.T) {
 			AuthorizeURL:    "https://api.twitter.com/oauth/authorize",
 			AccessTokenURL:  "https://api.twitter.com/oauth/access_token",
 		},
+		Noncer: &identityNoncer{expectedNonce},
 	}
 
-	auther := &auther{config, &fixedClock{time.Unix(unixTimestamp, 0)}, &fixedNoncer{expectedNonce}}
+	auther := &auther{config, &fixedClock{time.Unix(unixTimestamp, 0)}}
 	req, err := http.NewRequest("POST", config.Endpoint.AccessTokenURL, nil)
 	assert.Nil(t, err)
 	err = auther.setAccessTokenAuthHeader(req, expectedRequestToken, requestTokenSecret, expectedVerifier)
@@ -105,10 +107,11 @@ var twitterConfig = &Config{
 		AuthorizeURL:    "https://api.twitter.com/oauth/authorize",
 		AccessTokenURL:  "https://api.twitter.com/oauth/access_token",
 	},
+	Noncer: &identityNoncer{expectedNonce},
 }
 
 func TestTwitterParameterString(t *testing.T) {
-	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}, &fixedNoncer{expectedNonce}}
+	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}}
 	values := url.Values{}
 	values.Add("status", "Hello Ladies + Gentlemen, a signed OAuth request!")
 	// note: the reference example is old and uses api v1 in the URL
@@ -125,7 +128,7 @@ func TestTwitterParameterString(t *testing.T) {
 }
 
 func TestTwitterSignatureBase(t *testing.T) {
-	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}, &fixedNoncer{expectedNonce}}
+	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}}
 	values := url.Values{}
 	values.Add("status", "Hello Ladies + Gentlemen, a signed OAuth request!")
 	// note: the reference example is old and uses api v1 in the URL
@@ -148,7 +151,7 @@ func TestTwitterRequestAuthHeader(t *testing.T) {
 	expectedSignature := PercentEncode("tnnArxj06cWHq44gCs1OSKk/jLY=")
 	expectedTimestamp := "1318622958"
 
-	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}, &fixedNoncer{expectedNonce}}
+	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}}
 	values := url.Values{}
 	values.Add("status", "Hello Ladies + Gentlemen, a signed OAuth request!")
 
@@ -191,12 +194,4 @@ type fixedClock struct {
 
 func (c *fixedClock) Now() time.Time {
 	return c.now
-}
-
-type fixedNoncer struct {
-	nonce string
-}
-
-func (n *fixedNoncer) Nonce() string {
-	return n.nonce
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -32,11 +32,11 @@ func TestTransport(t *testing.T) {
 	config := &Config{
 		ConsumerKey:    expectedConsumerKey,
 		ConsumerSecret: "consumer_secret",
+		Noncer:         &identityNoncer{expectedNonce},
 	}
 	auther := &auther{
 		config: config,
 		clock:  &fixedClock{time.Unix(123456789, 0)},
-		noncer: &fixedNoncer{expectedNonce},
 	}
 	tr := &Transport{
 		source: StaticTokenSource(NewToken(expectedToken, "some_secret")),
@@ -69,9 +69,10 @@ func TestTransport_nilSource(t *testing.T) {
 	tr := &Transport{
 		source: nil,
 		auther: &auther{
-			config: &Config{},
-			clock:  &fixedClock{time.Unix(123456789, 0)},
-			noncer: &fixedNoncer{"any_nonce"},
+			config: &Config{
+				Noncer: &identityNoncer{"any_nonce"},
+			},
+			clock: &fixedClock{time.Unix(123456789, 0)},
 		},
 	}
 	client := &http.Client{Transport: tr}
@@ -86,9 +87,10 @@ func TestTransport_emptySource(t *testing.T) {
 	tr := &Transport{
 		source: StaticTokenSource(nil),
 		auther: &auther{
-			config: &Config{},
-			clock:  &fixedClock{time.Unix(123456789, 0)},
-			noncer: &fixedNoncer{"any_nonce"},
+			config: &Config{
+				Noncer: &identityNoncer{"any_nonce"},
+			},
+			clock: &fixedClock{time.Unix(123456789, 0)},
 		},
 	}
 	client := &http.Client{Transport: tr}


### PR DESCRIPTION
Make `Noncer` configurable via `Config` to be able to provide custom noncer to generate unique random strings.