### PR TITLE
Correct tiny typo in package docs

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -52,7 +52,7 @@ provider's authorization URL to grant the application access.
 
 	authorizationURL, err := config.AuthorizationURL(requestToken)
 	// handle err
-	http.Redirect(w, req, authorizationURL.String(), htt.StatusFound)
+	http.Redirect(w, req, authorizationURL.String(), http.StatusFound)
 
 Receive the callback from the OAuth1 provider in a handler.
 


### PR DESCRIPTION
The code block in the documentation should refer to package net/http.