### PR TITLE
Support PLAINTEXT signer

### DIFF
--- a/auther_test.go
+++ b/auther_test.go
@@ -83,6 +83,23 @@ func TestSigner_Default(t *testing.T) {
 	assert.Equal(t, expectedSignature, digest)
 }
 
+func TestSigner_PLAINTEXT(t *testing.T) {
+	consumerSecret := "consumer_secret"
+	config := &Config{
+		ConsumerSecret: consumerSecret,
+		Signer: &PLAINTEXTSigner{
+			ConsumerSecret: consumerSecret,
+		},
+	}
+	a := newAuther(config)
+	// assert that the PLAINTEXT signer is used
+	method := a.signer().Name()
+	digest, err := a.signer().Sign("token_secret", "")
+	assert.Nil(t, err)
+	assert.Equal(t, "PLAINTEXT", method)
+	assert.Equal(t, "consumer_secret&token_secret", digest)
+}
+
 type identitySigner struct{}
 
 func (s *identitySigner) Name() string {

--- a/signer.go
+++ b/signer.go
@@ -60,3 +60,20 @@ func (s *RSASigner) Sign(tokenSecret, message string) (string, error) {
 	}
 	return base64.StdEncoding.EncodeToString(signature), nil
 }
+
+// PLAINTEXTSigner signs messages with a concatenated consumer secret and token
+// secret as the key. https://oauth.net/core/1.0a/#rfc.section.9.4.1
+type PLAINTEXTSigner struct {
+	ConsumerSecret string
+}
+
+// Name returns the PLAINTEXT method.
+func (s *PLAINTEXTSigner) Name() string {
+	return "PLAINTEXT"
+}
+
+// Sign creates a concatenated consumer and token secret key and returns it.
+func (s *PLAINTEXTSigner) Sign(tokenSecret, message string) (string, error) {
+	signature := strings.Join([]string{s.ConsumerSecret, tokenSecret}, "&")
+	return signature, nil
+}


### PR DESCRIPTION
I have a need to sign OAuth 1.0 requests using PLAINTEXT as described in the spec: https://oauth.net/core/1.0a/#anchor21

Since it's documented in/supported by the protocol, it's possible that others may benefit from the implementation being included in the library natively.