### PR TITLE
change tumblr URLs to use https by default

### DIFF
--- a/tumblr/tumblr.go
+++ b/tumblr/tumblr.go
@@ -7,7 +7,7 @@ import (
 
 // Endpoint is Tumblr's OAuth 1a endpoint.
 var Endpoint = oauth1.Endpoint{
-	RequestTokenURL: "http://www.tumblr.com/oauth/request_token",
-	AuthorizeURL:    "http://www.tumblr.com/oauth/authorize",
-	AccessTokenURL:  "http://www.tumblr.com/oauth/access_token",
+	RequestTokenURL: "https://www.tumblr.com/oauth/request_token",
+	AuthorizeURL:    "https://www.tumblr.com/oauth/authorize",
+	AccessTokenURL:  "https://www.tumblr.com/oauth/access_token",
 }


### PR DESCRIPTION
creating an oAuth config with tumblr.Endpoint and then calling
RequestToken will return a http 401 error. defining your own
oauth.Endpoint with the tumblr URLs prefixed with https (instead of
http) fixes this problem.