### PR TITLE
Exclude empty access token from signing

### DIFF
--- a/auther.go
+++ b/auther.go
@@ -102,7 +102,9 @@ func (a *auther) setAccessTokenAuthHeader(req *http.Request, requestToken, reque
 // requests with an AccessToken (token credential) according to RFC 5849 3.1.
 func (a *auther) setRequestAuthHeader(req *http.Request, accessToken *Token) error {
 	oauthParams := a.commonOAuthParams()
-	oauthParams[oauthTokenParam] = accessToken.Token
+	if accessToken.Token != "" {
+		oauthParams[oauthTokenParam] = accessToken.Token
+	}
 	params, err := collectParameters(req, oauthParams)
 	if err != nil {
 		return err


### PR DESCRIPTION
I can't find where [spec](https://tools.ietf.org/html/rfc5849#section-3.4.2) is specifically clear about this.

However, the Base Signature and Authorization headers are including an empty `oauth_token` when an empty string is provided for the `requestToken`. This caused signing differences between the request and the Auth server.
