### PR TITLE
Add package discogs with an OAuth 1 Endpoint

### DIFF
--- a/discogs/discogs.go
+++ b/discogs/discogs.go
@@ -1,0 +1,13 @@
+// Package discogs provides constants for using OAuth1 to access Discogs.
+package discogs
+
+import (
+	"github.com/dghubble/oauth1"
+)
+
+// Endpoint is Discogs's OAuth 1.0a endpoint.
+var Endpoint = oauth1.Endpoint{
+	RequestTokenURL: "https://api.discogs.com/oauth/request_token",
+	AuthorizeURL:    "https://www.discogs.com/oauth/authorize",
+	AccessTokenURL:  "https://api.discogs.com/oauth/access_token",
+}


### PR DESCRIPTION
Hello!

I am currently writing a client library for the Discogs API and referencing this module as an [example](https://github.com/zachorosz/discogs-go#discogs-oauth-10a-flow) for OAuth. May I add this provider for their OAuth 1 endpoint?

For reference, here's a [link](https://www.discogs.com/developers#page:authentication,header:authentication-oauth-flow) outlining what's up with their OAuth flow.