### PR TITLE
Add PlainTextSigner

### DIFF
--- a/signer.go
+++ b/signer.go
@@ -39,6 +39,22 @@ func (s *HMACSigner) Sign(tokenSecret, message string) (string, error) {
 	return base64.StdEncoding.EncodeToString(signatureBytes), nil
 }
 
+// PlainTextSigner use the concatenation of the consumer secret and the token secret
+type PlainTextSigner struct {
+	ConsumerSecret string
+}
+
+// Name returns the PlainText method.
+func (s *PlainTextSigner) Name() string {
+	return "PLAINTEXT"
+}
+
+// Sign returns a concatenated consumer and token secret key according to
+// https://tools.ietf.org/html/rfc5849#section-3.4.4
+func (s *PlainTextSigner) Sign(tokenSecret, message string) (string, error) {
+	return strings.Join([]string{s.ConsumerSecret, tokenSecret}, "&"), nil
+}
+
 // RSASigner RSA PKCS1-v1_5 signs SHA1 digests of messages using the given
 // RSA private key.
 type RSASigner struct {


### PR DESCRIPTION
Hi @dghubble,

First of all, I would like to thank you for your work on this project.

The purpose of this PR is to add the support for the PLAINTEXT method, used to verify requests authenticity, according to the [section 3.4.4](https://tools.ietf.org/html/rfc5849#section-3.4.4) of the OAuth 1.0 RFC.

For the Google folks, I came accross this matter while writing a Go client for the [Sellsy API](https://api.sellsy.fr) (a french CRM) : the API was returning `oauth_problem=signature_invalid` because this API do not support the method used by default (HMAC-SHA1) at this time.