### PR TITLE
Update .travis.yml to add Go v1.13 and v1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - "1.10.x"
-  - "1.11.x"
   - "1.12.x"
+  - "1.13.x"
+  - "1.14.x"
 install:
   - go get golang.org/x/lint/golint
   - go get -v -t .

--- a/transport_test.go
+++ b/transport_test.go
@@ -78,7 +78,7 @@ func TestTransport_nilSource(t *testing.T) {
 	resp, err := client.Get("http://example.com")
 	assert.Nil(t, resp)
 	if assert.Error(t, err) {
-		assert.Equal(t, "Get http://example.com: oauth1: Transport's source is nil", err.Error())
+		assert.Contains(t, err.Error(), "oauth1: Transport's source is nil")
 	}
 }
 
@@ -95,7 +95,7 @@ func TestTransport_emptySource(t *testing.T) {
 	resp, err := client.Get("http://example.com")
 	assert.Nil(t, resp)
 	if assert.Error(t, err) {
-		assert.Equal(t, "Get http://example.com: oauth1: Token is nil", err.Error())
+		assert.Contains(t, err.Error(), "oauth1: Token is nil")
 	}
 }
 
@@ -108,7 +108,7 @@ func TestTransport_nilAuther(t *testing.T) {
 	resp, err := client.Get("http://example.com")
 	assert.Nil(t, resp)
 	if assert.Error(t, err) {
-		assert.Equal(t, "Get http://example.com: oauth1: Transport's auther is nil", err.Error())
+		assert.Contains(t, err.Error(), "oauth1: Transport's auther is nil")
 	}
 }
 


### PR DESCRIPTION
* http.Client quotes URLs in errors in Go v1.14. Update tests to assert errors contain desired messages, rather than exact equality
* Drop Go v1.10 and v1.11 from the test matrix