### PR TITLE
Throw an error if the more than one query value is provided

### DIFF
--- a/auther.go
+++ b/auther.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -210,6 +211,9 @@ func collectParameters(req *http.Request, oauthParams map[string]string) (map[st
 	params := map[string]string{}
 	for key, value := range req.URL.Query() {
 		// most backends do not accept duplicate query keys
+		if len(value) > 1 {
+			return nil, errors.New("oauth1: multiple query values for one key is not supported")
+		}
 		params[key] = value[0]
 	}
 	if req.Body != nil && req.Header.Get(contentType) == formContentType {


### PR DESCRIPTION
- How can it be reproduced?
  - Some backends (like Atlassian's) do support multi-value query params, but since this signs only the first value the server rejects (correctly) with an invalid signature.
- What did you expect?
  - That the api would handle the multi value query string parameters
- What actually occurred? 
  - It signed only the first value, causing an invalid signature error.

Despite the clear documentation that only single value keys are supported, it would be nice if it returned an error since the request would fail anyways. And the error from the server doesn't make it clear that this is a limitation of the api.