### PR TITLE
Configurable Nonces

### DIFF
--- a/auther.go
+++ b/auther.go
@@ -43,6 +43,12 @@ type auther struct {
 }
 
 func newAuther(config *Config) *auther {
+	if config == nil {
+		config = &Config{}
+	}
+	if config.Noncer == nil {
+		config.Noncer = Base64Noncer{}
+	}
 	return &auther{
 		config: config,
 	}
@@ -127,13 +133,9 @@ func (a *auther) commonOAuthParams() map[string]string {
 	return params
 }
 
-// Returns a base64 encoded random 32 byte string.
+// Returns a nonce using the configured Noncer.
 func (a *auther) nonce() string {
-	noncer := DefaultNoncer
-	if cfg := a.config; cfg != nil && cfg.Noncer != nil {
-		noncer = cfg.Noncer
-	}
-	return noncer.Nonce()
+	return a.config.Noncer.Nonce()
 }
 
 // Returns the Unix epoch seconds.

--- a/auther_test.go
+++ b/auther_test.go
@@ -17,9 +17,11 @@ func TestCommonOAuthParams(t *testing.T) {
 	}{
 		{
 			&auther{
-				&Config{ConsumerKey: "some_consumer_key"},
+				&Config{
+					ConsumerKey: "some_consumer_key",
+					Noncer:      &fixedNoncer{"some_nonce"},
+				},
 				&fixedClock{time.Unix(50037133, 0)},
-				&fixedNoncer{"some_nonce"},
 			},
 			map[string]string{
 				"oauth_consumer_key":     "some_consumer_key",
@@ -31,9 +33,12 @@ func TestCommonOAuthParams(t *testing.T) {
 		},
 		{
 			&auther{
-				&Config{ConsumerKey: "some_consumer_key", Realm: "photos"},
+				&Config{
+					ConsumerKey: "some_consumer_key",
+					Realm:       "photos",
+					Noncer:      &fixedNoncer{"some_nonce"},
+				},
 				&fixedClock{time.Unix(50037133, 0)},
-				&fixedNoncer{"some_nonce"},
 			},
 			map[string]string{
 				"oauth_consumer_key":     "some_consumer_key",

--- a/auther_test.go
+++ b/auther_test.go
@@ -57,7 +57,7 @@ func TestCommonOAuthParams(t *testing.T) {
 }
 
 func TestNonce(t *testing.T) {
-	auther := &auther{}
+	auther := newAuther(nil)
 	nonce := auther.nonce()
 	// assert that 32 bytes (256 bites) become 44 bytes since a base64 byte
 	// zeros the 2 high bits. 3 bytes convert to 4 base64 bytes, 40 base64 bytes
@@ -67,7 +67,7 @@ func TestNonce(t *testing.T) {
 }
 
 func TestEpoch(t *testing.T) {
-	a := &auther{}
+	a := newAuther(nil)
 	// assert that a real time is used by default
 	assert.InEpsilon(t, time.Now().Unix(), a.epoch(), 1)
 	// assert that the fixed clock can be used for testing

--- a/config.go
+++ b/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	Realm string
 	// OAuth1 Signer (defaults to HMAC-SHA1)
 	Signer Signer
+	// Noncer creates request nonces (defaults to DefaultNoncer)
+	Noncer Noncer
 }
 
 // NewConfig returns a new Config with the given consumer key and secret.

--- a/noncer.go
+++ b/noncer.go
@@ -11,58 +11,24 @@ type Noncer interface {
 	Nonce() string
 }
 
-// NoncerFunc is an adapter to allow the use of
-// ordinary functions as Noncers. If f is a function
-// with the appropriate signature, NoncerFunc(f) is a
-// Noncer that calls f.
-type NoncerFunc func() string
-
-// Nonce calls f().
-func (f NoncerFunc) Nonce() string {
-	return f()
-}
-
-var (
-	// DefaultNoncer is the default Noncer. It reads 32
-	// bytes from crypto/rand and returns those bytes as a
-	// base64 encoded string.
-	DefaultNoncer Noncer = Base64Noncer{
-		Length: 32,
-	}
-)
-
-// Base64Noncer reads Length bytes from crypto/rand and
-// returns those bytes as a base64 encoded string. If
-// Length is 0, 32 bytes are read.
-type Base64Noncer struct {
-	Length int
-}
+// Base64Noncer reads 32 bytes from crypto/rand and
+// returns those bytes as a base64 encoded string.
+type Base64Noncer struct{}
 
 // Nonce provides a random nonce string.
 func (n Base64Noncer) Nonce() string {
-	length := n.Length
-	if length == 0 {
-		length = 32
-	}
-	b := make([]byte, length)
+	b := make([]byte, 32)
 	rand.Read(b)
 	return base64.StdEncoding.EncodeToString(b)
 }
 
-// HexNoncer reads Length bytes from crypto/rand and
-// returns those bytes as a base64 encoded string. If
-// Length is 0, 32 bytes are read.
-type HexNoncer struct {
-	Length int
-}
+// HexNoncer reads 32 bytes from crypto/rand and
+// returns those bytes as a base64 encoded string.
+type HexNoncer struct{}
 
 // Nonce provides a random nonce string.
 func (n HexNoncer) Nonce() string {
-	length := n.Length
-	if length == 0 {
-		length = 32
-	}
-	b := make([]byte, length)
+	b := make([]byte, 32)
 	rand.Read(b)
 	return hex.EncodeToString(b)
 }

--- a/noncer.go
+++ b/noncer.go
@@ -26,17 +26,43 @@ var (
 	// DefaultNoncer is the default Noncer. It reads 32
 	// bytes from crypto/rand and returns those bytes as a
 	// base64 encoded string.
-	DefaultNoncer Noncer = NoncerFunc(func() string {
-		b := make([]byte, 32)
-		rand.Read(b)
-		return base64.StdEncoding.EncodeToString(b)
-	})
-
-	// HexNoncer reads 16 bytes from crypto/rand and returns
-	// those bytes as a hex encoded string.
-	HexNoncer Noncer = NoncerFunc(func() string {
-		b := make([]byte, 16)
-		rand.Read(b)
-		return hex.EncodeToString(b)
-	})
+	DefaultNoncer Noncer = Base64Noncer{
+		Length: 32,
+	}
 )
+
+// Base64Noncer reads Length bytes from crypto/rand and
+// returns those bytes as a base64 encoded string. If
+// Length is 0, 32 bytes are read.
+type Base64Noncer struct {
+	Length int
+}
+
+// Nonce provides a random nonce string.
+func (n Base64Noncer) Nonce() string {
+	length := n.Length
+	if length == 0 {
+		length = 32
+	}
+	b := make([]byte, length)
+	rand.Read(b)
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+// HexNoncer reads Length bytes from crypto/rand and
+// returns those bytes as a base64 encoded string. If
+// Length is 0, 32 bytes are read.
+type HexNoncer struct {
+	Length int
+}
+
+// Nonce provides a random nonce string.
+func (n HexNoncer) Nonce() string {
+	length := n.Length
+	if length == 0 {
+		length = 32
+	}
+	b := make([]byte, length)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/noncer.go
+++ b/noncer.go
@@ -1,0 +1,42 @@
+package oauth1
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+)
+
+// Noncer provides random nonce strings.
+type Noncer interface {
+	Nonce() string
+}
+
+// NoncerFunc is an adapter to allow the use of
+// ordinary functions as Noncers. If f is a function
+// with the appropriate signature, NoncerFunc(f) is a
+// Noncer that calls f.
+type NoncerFunc func() string
+
+// Nonce calls f().
+func (f NoncerFunc) Nonce() string {
+	return f()
+}
+
+var (
+	// DefaultNoncer is the default Noncer. It reads 32
+	// bytes from crypto/rand and returns those bytes as a
+	// base64 encoded string.
+	DefaultNoncer Noncer = NoncerFunc(func() string {
+		b := make([]byte, 32)
+		rand.Read(b)
+		return base64.StdEncoding.EncodeToString(b)
+	})
+
+	// HexNoncer reads 16 bytes from crypto/rand and returns
+	// those bytes as a hex encoded string.
+	HexNoncer Noncer = NoncerFunc(func() string {
+		b := make([]byte, 16)
+		rand.Read(b)
+		return hex.EncodeToString(b)
+	})
+)

--- a/reference_test.go
+++ b/reference_test.go
@@ -33,9 +33,10 @@ func TestTwitterRequestTokenAuthHeader(t *testing.T) {
 			AuthorizeURL:    "https://api.twitter.com/oauth/authorize",
 			AccessTokenURL:  "https://api.twitter.com/oauth/access_token",
 		},
+		Noncer: &fixedNoncer{expectedNonce},
 	}
 
-	auther := &auther{config, &fixedClock{time.Unix(unixTimestamp, 0)}, &fixedNoncer{expectedNonce}}
+	auther := &auther{config, &fixedClock{time.Unix(unixTimestamp, 0)}}
 	req, err := http.NewRequest("POST", config.Endpoint.RequestTokenURL, nil)
 	assert.Nil(t, err)
 	err = auther.setRequestTokenAuthHeader(req)
@@ -70,9 +71,10 @@ func TestTwitterAccessTokenAuthHeader(t *testing.T) {
 			AuthorizeURL:    "https://api.twitter.com/oauth/authorize",
 			AccessTokenURL:  "https://api.twitter.com/oauth/access_token",
 		},
+		Noncer: &fixedNoncer{expectedNonce},
 	}
 
-	auther := &auther{config, &fixedClock{time.Unix(unixTimestamp, 0)}, &fixedNoncer{expectedNonce}}
+	auther := &auther{config, &fixedClock{time.Unix(unixTimestamp, 0)}}
 	req, err := http.NewRequest("POST", config.Endpoint.AccessTokenURL, nil)
 	assert.Nil(t, err)
 	err = auther.setAccessTokenAuthHeader(req, expectedRequestToken, requestTokenSecret, expectedVerifier)
@@ -105,10 +107,11 @@ var twitterConfig = &Config{
 		AuthorizeURL:    "https://api.twitter.com/oauth/authorize",
 		AccessTokenURL:  "https://api.twitter.com/oauth/access_token",
 	},
+	Noncer: &fixedNoncer{expectedNonce},
 }
 
 func TestTwitterParameterString(t *testing.T) {
-	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}, &fixedNoncer{expectedNonce}}
+	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}}
 	values := url.Values{}
 	values.Add("status", "Hello Ladies + Gentlemen, a signed OAuth request!")
 	// note: the reference example is old and uses api v1 in the URL
@@ -125,7 +128,7 @@ func TestTwitterParameterString(t *testing.T) {
 }
 
 func TestTwitterSignatureBase(t *testing.T) {
-	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}, &fixedNoncer{expectedNonce}}
+	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}}
 	values := url.Values{}
 	values.Add("status", "Hello Ladies + Gentlemen, a signed OAuth request!")
 	// note: the reference example is old and uses api v1 in the URL
@@ -148,7 +151,7 @@ func TestTwitterRequestAuthHeader(t *testing.T) {
 	expectedSignature := PercentEncode("tnnArxj06cWHq44gCs1OSKk/jLY=")
 	expectedTimestamp := "1318622958"
 
-	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}, &fixedNoncer{expectedNonce}}
+	auther := &auther{twitterConfig, &fixedClock{time.Unix(unixTimestampOfRequest, 0)}}
 	values := url.Values{}
 	values.Add("status", "Hello Ladies + Gentlemen, a signed OAuth request!")
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -32,11 +32,11 @@ func TestTransport(t *testing.T) {
 	config := &Config{
 		ConsumerKey:    expectedConsumerKey,
 		ConsumerSecret: "consumer_secret",
+		Noncer:         &fixedNoncer{expectedNonce},
 	}
 	auther := &auther{
 		config: config,
 		clock:  &fixedClock{time.Unix(123456789, 0)},
-		noncer: &fixedNoncer{expectedNonce},
 	}
 	tr := &Transport{
 		source: StaticTokenSource(NewToken(expectedToken, "some_secret")),
@@ -69,9 +69,8 @@ func TestTransport_nilSource(t *testing.T) {
 	tr := &Transport{
 		source: nil,
 		auther: &auther{
-			config: &Config{},
+			config: &Config{Noncer: &fixedNoncer{"any_nonce"}},
 			clock:  &fixedClock{time.Unix(123456789, 0)},
-			noncer: &fixedNoncer{"any_nonce"},
 		},
 	}
 	client := &http.Client{Transport: tr}
@@ -86,9 +85,8 @@ func TestTransport_emptySource(t *testing.T) {
 	tr := &Transport{
 		source: StaticTokenSource(nil),
 		auther: &auther{
-			config: &Config{},
+			config: &Config{Noncer: &fixedNoncer{"any_nonce"}},
 			clock:  &fixedClock{time.Unix(123456789, 0)},
-			noncer: &fixedNoncer{"any_nonce"},
 		},
 	}
 	client := &http.Client{Transport: tr}


### PR DESCRIPTION
We're working with a service that uses OAuth 1.0 for authentication, but does not accept non-alphanumeric characters in the nonce. That's peculiar to this service, but by exporting the existing Noncer interface and adding a Noncer field to the Config, it's easy to enable configuration for this situation. Because this is a general change, other peculiar cases can now also be covered.

The existing behavior is part of an exported DefaultNoncer, which is the default used when no custom Noncer is specified. DefaultNoncer is a Base64Noncer with Length 32.

If anyone else needs a noncer that excludes non-alphanumeric characters, a new HexNoncer is also included. HexNoncer works just like Base64Noncer, but encodes in hexadecimal instead of base64.