### PR TITLE
Ignore empty oauth_token_secret (accessSecret)

### DIFF
--- a/config.go
+++ b/config.go
@@ -170,8 +170,8 @@ func (c *Config) AccessToken(requestToken, requestSecret, verifier string) (acce
 	}
 	accessToken = values.Get(oauthTokenParam)
 	accessSecret = values.Get(oauthTokenSecretParam)
-	if accessToken == "" || accessSecret == "" {
-		return "", "", errors.New("oauth1: Response missing oauth_token or oauth_token_secret")
+	if accessToken == "" {
+		return "", "", errors.New("oauth1: Response missing oauth_token")
 	}
 	return accessToken, accessSecret, nil
 }


### PR DESCRIPTION
I try to use oauth1 for Evernote.
I get requestToken and verifier sucessfully, but I can't get accessToken because an error: `oauth1: Response missing oauth_token or oauth_token_secret`
According to Evernote documentation https://dev.evernote.com/doc/articles/authentication.php (see step 3 - Access Token Response) they don't provide `oauth_token_secret`. It will always be empty.

![Снимок экрана от 2021-07-13 23-56-51](https://user-images.githubusercontent.com/9244347/125524778-e0eaa088-2b71-4085-b891-28119c239257.png)