### PR TITLE
Read body of error response

### DIFF
--- a/config.go
+++ b/config.go
@@ -155,7 +155,7 @@ func (c *Config) AccessToken(requestToken, requestSecret, verifier string) (acce
 		return "", "", err
 	}
 	// when err is nil, resp contains a non-nil resp.Body which must be closed
-	defer resp.Body.Close(
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", fmt.Errorf("oauth1: Unable to read body of response with status %d: %w", resp.StatusCode, err)

--- a/config.go
+++ b/config.go
@@ -79,12 +79,12 @@ func (c *Config) RequestToken() (requestToken, requestSecret string, err error) 
 	}
 	// when err is nil, resp contains a non-nil resp.Body which must be closed
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", "", fmt.Errorf("oauth1: Server returned status %d", resp.StatusCode)
-	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("oauth1: Unable to read body of response with status %d: %w", resp.StatusCode, err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", "", fmt.Errorf("oauth1: Server returned status %d: %s", resp.StatusCode, body)
 	}
 	// ParseQuery to decode URL-encoded application/x-www-form-urlencoded body
 	values, err := url.ParseQuery(string(body))
@@ -155,13 +155,13 @@ func (c *Config) AccessToken(requestToken, requestSecret, verifier string) (acce
 		return "", "", err
 	}
 	// when err is nil, resp contains a non-nil resp.Body which must be closed
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", "", fmt.Errorf("oauth1: Server returned status %d", resp.StatusCode)
-	}
+	defer resp.Body.Close(
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("oauth1: Unable to read body of response with status %d: %w", resp.StatusCode, err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", "", fmt.Errorf("oauth1: Server returned status %d: %s", resp.StatusCode, body)
 	}
 	// ParseQuery to decode URL-encoded application/x-www-form-urlencoded body
 	values, err := url.ParseQuery(string(body))


### PR DESCRIPTION
Previously a failing request to retrieve a request token or an access token with an unexpected status code was hard to debug, because additional information returned by the server in the body of the response was inaccessible to the user of this library.

This patch changes that by including the body in the error message. Since the body is now read before the potential status code error is returned, but it is crucial information for debugging, we also include the status code in an error resulting from reading the body.