### PR TITLE
Read Body in RequestToken and AccessToken methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Notable changes between releases.
 
 ## Latest
 
+* Show body when `RequestToken` or `AccessToken` requests return an invalid status code ([#54](https://github.com/dghubble/oauth1/pull/54))
+
 ## v0.7.0
 
 * Add an `HMAC256Signer` ([#40](https://github.com/dghubble/oauth1/pull/40))

--- a/config.go
+++ b/config.go
@@ -79,13 +79,15 @@ func (c *Config) RequestToken() (requestToken, requestSecret string, err error) 
 	}
 	// when err is nil, resp contains a non-nil resp.Body which must be closed
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", "", fmt.Errorf("oauth1: Server returned status %d", resp.StatusCode)
-	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("oauth1: error reading Body: %v", err)
 	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", "", fmt.Errorf("oauth1: invalid status %d: %s", resp.StatusCode, body)
+	}
+
 	// ParseQuery to decode URL-encoded application/x-www-form-urlencoded body
 	values, err := url.ParseQuery(string(body))
 	if err != nil {
@@ -156,13 +158,15 @@ func (c *Config) AccessToken(requestToken, requestSecret, verifier string) (acce
 	}
 	// when err is nil, resp contains a non-nil resp.Body which must be closed
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", "", fmt.Errorf("oauth1: Server returned status %d", resp.StatusCode)
-	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("oauth1: error reading Body: %v", err)
 	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", "", fmt.Errorf("oauth1: invalid status %d: %s", resp.StatusCode, body)
+	}
+
 	// ParseQuery to decode URL-encoded application/x-www-form-urlencoded body
 	values, err := url.ParseQuery(string(body))
 	if err != nil {


### PR DESCRIPTION
* For non-nil RequestToken or AccessToken requests, read the body before checking the status code, in case it has useful
information to include

Co-authored-by: Dennis Schridde <dennis.schridde@freiheit.com>
Co-authored-by: Dalton Hubble <dghubble@mgmail.com>