### PR TITLE
Fix oauth_callback_confirmed comparison when server returns extra whitespace

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 const (
@@ -89,7 +90,7 @@ func (c *Config) RequestToken() (requestToken, requestSecret string, err error) 
 	}
 
 	// ParseQuery to decode URL-encoded application/x-www-form-urlencoded body
-	values, err := url.ParseQuery(string(body))
+	values, err := url.ParseQuery(strings.TrimSpace(string(body)))
 	if err != nil {
 		return "", "", err
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -63,7 +63,8 @@ func newRequestTokenServer(t *testing.T, data url.Values) *httptest.Server {
 		assert.Equal(t, "POST", req.Method)
 		assert.NotEmpty(t, req.Header.Get("Authorization"))
 		w.Header().Set(contentType, formContentType)
-		w.Write([]byte(data.Encode()))
+		// Add a newline to ensure parsing works for servers that return extra whitespace
+		w.Write([]byte(data.Encode() + "\n"))
 	})
 }
 
@@ -91,7 +92,7 @@ func newUnparseableBodyServer() *httptest.Server {
 }
 
 func TestConfigRequestToken(t *testing.T) {
-	expectedToken := "reqest_token"
+	expectedToken := "request_token"
 	expectedSecret := "request_secret"
 	data := url.Values{}
 	data.Add("oauth_token", expectedToken)
@@ -124,7 +125,7 @@ func TestConfigRequestToken_InvalidRequestTokenURL(t *testing.T) {
 }
 
 func TestConfigRequestToken_CallbackNotConfirmed(t *testing.T) {
-	const expectedToken = "reqest_token"
+	const expectedToken = "request_token"
 	const expectedSecret = "request_secret"
 	data := url.Values{}
 	data.Add("oauth_token", expectedToken)


### PR DESCRIPTION
I'm working against the Netsuite API and found that there is an added newline in the response body during the `RequestToken` flow, and since their response sets `oauth_callback_confirmed` as the last body parameter, this causes the comparison `values.Get(oauthCallbackConfirmedParam) != "true"` to fail while comparing against the parsed value `true\n`.

Since the tests don't use the same order of parameters in the mocked response I've added a newline to the response and trimmed that during body parsing to ensure trailing whitespace always gets removed. In this case the mock change will cause a failure without the `TrimSpace` while checking the `expectedSecret`.