### PR TITLE
Update Go test matrix to add Go v1.18

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,18 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.17']
+        go: ['1.17', '1.18']
     steps:
       - name: setup
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{matrix.go}}
 
       - name: checkout
-        uses: actions/checkout@v2
-
-      - name: tools
-        run: go get golang.org/x/lint/golint
+        uses: actions/checkout@v3
 
       - name: test
         run: make

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: test vet lint fmt
+all: test vet fmt
 
 .PHONY: test
 test:
@@ -8,10 +8,6 @@ test:
 .PHONY: vet
 vet:
 	@go vet -all $$(go list ./... | grep -v examples)
-
-.PHONY: lint
-lint:
-	@golint -set_exit_status ./...
 
 .PHONY: fmt
 fmt:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/dghubble/oauth1
 
-go 1.16
+go 1.17
 
 require github.com/stretchr/testify v1.7.1
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)


### PR DESCRIPTION
* Update checkout and setup-go Github Actions
* Remove golint since its deprecated
* Drop Go v1.16