### PR TITLE
Feature/support verifying request

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -48,26 +48,26 @@ func PercentDecode(input string) (string, error) {
 	return t.String(), nil
 }
 
-// ishex is copied from url
+// ishex is copied from url package
 func ishex(c byte) bool {
 	switch {
 	case '0' <= c && c <= '9':
 		return true
-	case 'a' <= c && c <= 'f':
-		return true
+	// https://datatracker.ietf.org/doc/html/rfc5849#section-3.6
+	// The two hexadecimal characters used to represent encoded	characters MUST be uppercase.
 	case 'A' <= c && c <= 'F':
 		return true
 	}
 	return false
 }
 
-// unhex is copied from url
+// unhex is copied from url package
 func unhex(c byte) byte {
 	switch {
 	case '0' <= c && c <= '9':
 		return c - '0'
-	case 'a' <= c && c <= 'f':
-		return c - 'a' + 10
+	// https://datatracker.ietf.org/doc/html/rfc5849#section-3.6
+	// The two hexadecimal characters used to represent encoded	characters MUST be uppercase.
 	case 'A' <= c && c <= 'F':
 		return c - 'A' + 10
 	}

--- a/decode.go
+++ b/decode.go
@@ -1,0 +1,75 @@
+package oauth1
+
+import (
+	"net/url"
+	"strings"
+)
+
+// PercentDecode percent-decodes a string according to RFC 5849 3.6.
+// https://datatracker.ietf.org/doc/html/rfc5849#section-3.6
+// In summary, only decode %XX
+//
+// Modified from url.unescape
+func PercentDecode(input string) (string, error) {
+	// Count %, check that they're well-formed.
+	n := 0
+	for i := 0; i < len(input); {
+		switch input[i] {
+		case '%':
+			n++
+			if i+2 >= len(input) || !ishex(input[i+1]) || !ishex(input[i+2]) {
+				input = input[i:]
+				if len(input) > 3 {
+					input = input[:3]
+				}
+				return "", url.EscapeError(input)
+			}
+			i += 3
+		default:
+			i++
+		}
+	}
+
+	if n == 0 {
+		return input, nil
+	}
+
+	var t strings.Builder
+	t.Grow(len(input) - 2*n)
+	for i := 0; i < len(input); i++ {
+		switch input[i] {
+		case '%':
+			t.WriteByte(unhex(input[i+1])<<4 | unhex(input[i+2]))
+			i += 2
+		default:
+			t.WriteByte(input[i])
+		}
+	}
+	return t.String(), nil
+}
+
+// ishex is copied from url
+func ishex(c byte) bool {
+	switch {
+	case '0' <= c && c <= '9':
+		return true
+	case 'a' <= c && c <= 'f':
+		return true
+	case 'A' <= c && c <= 'F':
+		return true
+	}
+	return false
+}
+
+// unhex is copied from url
+func unhex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10
+	}
+	return 0
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,0 +1,39 @@
+package oauth1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPercentDecode(t *testing.T) {
+	// copied from TestPercentEncode
+	cases := []struct {
+		expected string
+		input    string
+	}{
+		{" ", "%20"},
+		{"%", "%25"},
+		{"&", "%26"},
+		{"-._", "-._"},
+		{" /=+", "%20%2F%3D%2B"},
+		{"Ladies + Gentlemen", "Ladies%20%2B%20Gentlemen"},
+		{"An encoded string!", "An%20encoded%20string%21"},
+		{"Dogs, Cats & Mice", "Dogs%2C%20Cats%20%26%20Mice"},
+		{"☃", "%E2%98%83"},
+	}
+	for _, c := range cases {
+		output, err := PercentDecode(c.input)
+		require.NoError(t, err)
+		if output != c.expected {
+			t.Errorf("expected %s, got %s", c.expected, output)
+		}
+	}
+}
+
+func TestPercentDecode_InvalidPercent(t *testing.T) {
+	for _, c := range []string{"%2", "%%%%"} {
+		output, err := PercentDecode(c)
+		require.Error(t, err, output)
+	}
+}

--- a/verifier.go
+++ b/verifier.go
@@ -163,6 +163,9 @@ func NewHMACVerifier(c *Config, tokenSecret string) *HMACVerifier {
 
 // Verify verifies the signature based on base string using hmac + hash selected in initialization.
 func (v *HMACVerifier) Verify(baseString, actualSignature string) error {
+	// https://datatracker.ietf.org/doc/html/rfc5849#section-3.4.2
+	// signature is base64 encoded
+	// Be careful, Signer.Sign() returns base64-encoded signature
 	expectedSignature, err := v.signer.Sign(v.tokenSecret, baseString)
 	if err != nil {
 		return fmt.Errorf("oauth1: error signing request for validating signature: %w", err)

--- a/verifier.go
+++ b/verifier.go
@@ -1,0 +1,282 @@
+package oauth1
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Verifier verifies a OAuth1 signature based on base string.
+type Verifier interface {
+	Verify(baseString, actualSignature string) error
+}
+
+// GetVerifier returns a verifier based on consumer key & signature method.
+//
+// GetVerifier should also make sure nonce is unique across all requests with the
+// same timestamp, client credentials, and token combinations.
+type GetVerifier func(consumerKey, signatureMethod string, params map[string]string) (Verifier, error)
+
+// VerifierManager verifies OAuth1 request.
+// VerifierManager does NOT support duplicated parameters.
+type VerifierManager struct {
+	// verifier should find the corresponding verifier according to the consumer key & signature method.
+	verifier GetVerifier
+	// defaultScheme implies the scheme that should be used in verification
+	// if scheme cannot be found from request.
+	defaultScheme string
+	// maxClockSkew limits the max timestamp difference between client and server.
+	// Negative value implies no limit.
+	maxClockSkew time.Duration
+}
+
+// NewVerifierManager initializes VerifierManager.
+// For the meaning of each field, please refer to the VerifierManager.
+func NewVerifierManager(getVerifier GetVerifier, defaultScheme string, maxClockSkew time.Duration) *VerifierManager {
+	return &VerifierManager{
+		verifier:      getVerifier,
+		defaultScheme: defaultScheme,
+		maxClockSkew:  maxClockSkew,
+	}
+}
+
+// Verify verifies a OAuth1 request.
+// NOT supporting duplicated parameters.
+// NOT examining whether nonce is unique across all requests with the
+// same timestamp, client credentials, and token combinations.
+func (v *VerifierManager) Verify(req *http.Request) error {
+	v.makeURLAbs(req)
+	params, actualSignature, err := collectRequestParameters(req)
+	if err != nil {
+		return fmt.Errorf("oauth1: error collecting request parameters: %w", err)
+	}
+
+	timestamp := params[oauthTimestampParam]
+	err = v.checkTimestamp(timestamp)
+	if err != nil {
+		return fmt.Errorf("oauth1: error checking timestamp: %w", err)
+	}
+
+	consumerKey := params[oauthConsumerKeyParam]
+	signatureMethod := params[oauthSignatureMethodParam]
+	verifier, err := v.verifier(consumerKey, signatureMethod, params)
+	if err != nil {
+		return fmt.Errorf("oauth1: error getting verifier: %w", err)
+	}
+
+	baseString := signatureBase(req, params)
+	err = verifier.Verify(baseString, actualSignature)
+	if err != nil {
+		return fmt.Errorf("oauth1: error verifying signature: %w", err)
+	}
+	return nil
+}
+
+// makeURLAbs tries to make sure request url has scheme & host.
+// If missing host, makeURLAbs gets it from request.Host.
+// If missing scheme, makeURLAbs tries to get it from header.
+// Currently makeURLAbs only utilizes in Forwarded & X-Forwarded-Proto.
+func (v *VerifierManager) makeURLAbs(req *http.Request) {
+	if req.URL.IsAbs() {
+		return
+	}
+	// we need scheme & host
+	req.URL.Host = req.Host
+
+	raw := req.Header.Get(ForwardedHeader) // standard
+	scheme := parseForwardedHeader(raw)[ForwardedHeaderProtoField]
+	if len(scheme) != 0 {
+		req.URL.Scheme = scheme
+		return
+	}
+	scheme = req.Header.Get(XForwardedProto) // de-facto standard
+	if len(scheme) != 0 {
+		req.URL.Scheme = scheme
+		return
+	}
+	req.URL.Scheme = v.defaultScheme
+}
+
+// checkTimestamp only supports timestamp that is expressed in the number of seconds since January 1, 1970 00:00:00 GMT.
+// https://datatracker.ietf.org/doc/html/rfc5849#section-3.3
+// Unless otherwise specified by the server's documentation,
+// the timestamp is expressed in the number of seconds since January 1, 1970 00:00:00 GMT.
+func (v *VerifierManager) checkTimestamp(rawTimestamp string) error {
+	if v.maxClockSkew < 0 {
+		return nil
+	}
+
+	timestamp, err := strconv.ParseInt(rawTimestamp, 10, 64)
+	if err != nil {
+		return fmt.Errorf("oauth1: error parsing timestamp: %w", err)
+	}
+	t := time.Unix(timestamp, 0)
+	now := time.Now()
+	if now.Sub(t) > v.maxClockSkew {
+		return fmt.Errorf(
+			"oauth1: clock skew out of sync. timestamp in request: %v, server timestamp: %v",
+			timestamp, now.Unix(),
+		)
+	}
+	return nil
+}
+
+// RSAVerifier verifies OAuth1 signatures.
+type RSAVerifier struct {
+	publicKey *rsa.PublicKey
+	hash      crypto.Hash
+}
+
+// NewRSAVerifier initializes RSAVerifier with rsa public key & hash.
+func NewRSAVerifier(publicKey *rsa.PublicKey, hash crypto.Hash) *RSAVerifier {
+	return &RSAVerifier{
+		publicKey,
+		hash,
+	}
+}
+
+// Verify verifies the signature based on base string using rsa + hash selected in initialization.
+func (v *RSAVerifier) Verify(baseString, actualSignature string) error {
+	// https://datatracker.ietf.org/doc/html/rfc5849#section-3.4.3
+	// signature is base64 encoded
+	signature, err := base64.StdEncoding.DecodeString(actualSignature)
+	if err != nil {
+		return fmt.Errorf("oauth1: error base64 decoding signature: %w", err)
+	}
+
+	hash := v.hash.New()
+	_, err = hash.Write([]byte(baseString))
+	if err != nil {
+		return fmt.Errorf("oauth1: error hashing parameters: %w", err)
+	}
+	digest := hash.Sum(nil)
+
+	err = rsa.VerifyPKCS1v15(v.publicKey, v.hash, digest[:], signature)
+	if err != nil {
+		return fmt.Errorf("oauth1: error verifying rsa signature: %w", err)
+	}
+	return nil
+}
+
+// HMACVerifier verifies OAuth1 signatures.
+type HMACVerifier struct {
+	signer      Signer
+	tokenSecret string
+}
+
+// NewHMACVerifier initializes HMACVerifier with hmac signer &
+// optional oauth token secret.
+// Default signer is HMAC-SHA1.
+func NewHMACVerifier(c *Config, tokenSecret string) *HMACVerifier {
+	return &HMACVerifier{
+		newAuther(c).signer(),
+		tokenSecret,
+	}
+}
+
+// Verify verifies the signature based on base string using hmac + hash selected in initialization.
+func (v *HMACVerifier) Verify(baseString, actualSignature string) error {
+	expectedSignature, err := v.signer.Sign(v.tokenSecret, baseString)
+	if err != nil {
+		return fmt.Errorf("oauth1: error signing request for validating signature: %w", err)
+	}
+
+	// https://datatracker.ietf.org/doc/html/rfc5849#section-3.5.1
+	// Still there are clients that don't escape signature
+	if actualSignature != expectedSignature {
+		return fmt.Errorf("oauth1: invalid signature")
+	}
+	return nil
+}
+
+// collectRequestParameters collects request parameters from
+//   1. the request query,
+//   2. the request body provided the body is single part & form encoded & form content type header is set,
+//   3. and authorization header.
+// The returned map of collected parameter keys and values follow RFC 5849 3.4.1.3,
+// except duplicate parameters are not supported.
+func collectRequestParameters(req *http.Request) (map[string]string, string, error) {
+	// parse from query string & body
+	params, err := collectParameters(req, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// https://datatracker.ietf.org/doc/html/rfc5849#section-3.5.1
+	// according to 3.5.1.
+	// protocol parameters can be transmitted using the HTTP "Authorization" header field
+	// with the auth-scheme name set to "OAuth" (case insensitive).
+	authHeader := req.Header.Get(authorizationHeaderParam)
+	if strings.HasPrefix(strings.ToLower(authHeader), strings.ToLower(authorizationPrefix)) {
+		// case-insensitively trim prefix
+		authHeader = authHeader[len(authorizationPrefix):]
+
+		// https://datatracker.ietf.org/doc/html/rfc5849#section-3.5.1
+		// according to 3.5.1. parameters are separated by a "," character (ASCII code 44) and OPTIONAL linear whitespace per
+		for _, raw := range strings.Split(authHeader, ",") {
+			raw = strings.TrimSpace(raw)
+			// https://datatracker.ietf.org/doc/html/rfc5849#section-3.5.1
+			// according to 3.5.1. key & value are separated by =
+			kv := strings.SplitN(raw, "=", 2)
+
+			k := kv[0]
+			// https://datatracker.ietf.org/doc/html/rfc5849#section-3.5.1
+			// according to 3.5.1. unescape key
+			k, err := PercentDecode(k)
+			if err != nil {
+				return nil, "", fmt.Errorf("oauth1: error unescaping authorization field name: %w", err)
+			}
+			// https://datatracker.ietf.org/doc/html/rfc5849#section-3.4.1.3.1
+			// according to 3.4.1.3.1. the realm parameter is excluded
+			if k == realmParam {
+				continue
+			}
+
+			// https://datatracker.ietf.org/doc/html/rfc5849#section-3.5.1
+			// according to 3.5.1. value is wrapped by "
+			v := strings.Trim(kv[1], `"`)
+			// https://datatracker.ietf.org/doc/html/rfc5849#section-3.5.1
+			// according to 3.5.1. unescape value
+			v, err = PercentDecode(v)
+			if err != nil {
+				return nil, "", fmt.Errorf("oauth1: error unescaping oauth parameters")
+			}
+			// dghubble does NOT support params with duplicate keys
+			params[k] = v
+		}
+	}
+
+	signatureBase64 := params[oauthSignatureParam]
+	delete(params, oauthSignatureParam)
+
+	return params, signatureBase64, nil
+}
+
+const (
+	XForwardedProto = "X-Forwarded-Proto"
+	ForwardedHeader = "Forwarded"
+
+	ForwardedHeaderProtoField = "proto"
+)
+
+// parseForwardedHeader parses Forwarded header.
+// parseForwardedHeader does NOT return nil.
+//
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
+// from Google: for="127.0.0.1";proto=https
+func parseForwardedHeader(forwarded string) map[string]string {
+	result := map[string]string{}
+	if len(forwarded) == 0 {
+		return result
+	}
+	for _, pair := range strings.Split(forwarded, ";") {
+		kv := strings.SplitN(pair, "=", 2)
+		result[kv[0]] = kv[1]
+	}
+	return result
+}

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -1,0 +1,165 @@
+package oauth1
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	_ Verifier = &RSAVerifier{}
+	_ Verifier = &HMACVerifier{}
+)
+
+const (
+	rsaKey = `MIIEowIBAAKCAQEAy45DIEXPGTM/h3DC4GJKN+7k1wyZo5VpMGjESRkmq2RJOW+CJ8dlqcir4COX9wQlvmIZKSD/UDuai9zTXs3yHm1CizrOmF4PE0xxC8kNUvQccffBImoWLLzFs0sJHk/r0GNByTh+glQZksXhOhIaFETDPG/04MdwppvKDIC8him4dhQSNtf+5B62tvR1vmSaiUIq16twOYqDRAxZNEJ+SQ6d4uubDfQzIvQDGxgSi50WFcuNGdlzZgQpKYofC5lci06QoHV145yDMhl429Oj6urgcSX9kmypRa2PAWSRo7hmPp/siFHDk9OS3pLlOuWkVfNpMTJ8pbN+1quyHW/0OwIDAQABAoIBAFszUyn7fQ2KY5VYVUfZYe1rkIY1dATR5X42AnPJ3ASAezpLlqIh+Y+3hCJ5cBXReuOw6hr+WMXm3ph5iQ558VfmliDxaSzlP5Xi8udX3itjifcaDSNRKrxCm8V4Ag7dugb04b25HR1hds/G7uFoyNx57ot+kdXAJd3QARfW+iCVdffnsLEl4osUJkNMYb75cqv51BWRt3nzkNXXBv5GRfywZMIuuRdp090eyqkgq6giofVLiuCcyJEMQuDAY/wo/np49wC+W2LMdOgZpqgmxnS7SHEMBtAbuh1mCccHS3sa3XOBPuC6kKs6kmJm85Xu+qnOn6qLTJQVs4xUhbz/BYECgYEA2j8mKlhT6UNmOVuSC7BkMPBupdBFWVjI2gbMDwIkEQ3vL+Q4sdqNJM1x6EubyXApWK/t3HmMYcSJ8ug1BH5T3FRTOeAkKiWmdI21NaHsgj2mOldJOVTYluDUVUE+5DvSHCZgIRpg9qDxu0eCrMimcoXrn5Et3xJeIrw6fo5Q0HsCgYEA7sSJlgNWcjElAVv0SEj2fDmAxbLtarVzmRAgJ7G4R2tZliofDWGVvavb2rsFODHzsOnpTSopBDknYyNAXWQ1LtvaRjt4qJecLChx+pXy05BTPfTJlBZbq5N7cscERcQe0KbyYVE+jF0+yMTZidfAOzIO6A0PX38shpaKQfUaf0ECgYAIf50E2RurYayBX0d4nQ3JuhMU8d9Bc2ue0dTwYKz23QwLWV+7zT7hx/4/hXIzjeKOSYuBoloNFJIqm1A1NJYfZkk3X7sIyR6KO1prFDsZdz0Z2HxJdzxX47lg+IFyccHkxrnHkDdmYy4GlOpJwCZ7HyvlssmOfjCcOagtdW1AMQKBgBUySWyR20jD6B8YxLTuFUOt7yqd2cnRVfPOpKwhcNSWSRu1nZAYi6yM5zWhyLLWbGXWPinlhkKjuEVqyboAvV/tkJEPkoSVAP5CkOvICAiUFW+4nXSSD41JyHnGBTEUWg/34iiVh9H6LSqxnwZHqv8WUJB1KFo39gH0t01nrvSBAoGBAMY8PqRGcqQzBVwPrFgQDpXzQT1kgdK9/Z+ou5m2laozMqzCzoMtMZwTK25BPXOu1c93EeFBP/V7JP1glWfHulBXNWXRm0qkNDQeTzRwDkB4Nqu9chbaDRSSwtWa+k93nHNiWqUfn8/XhU+b5mM6ObonlhM7QrffwH3o8Obpw34n`
+)
+
+func TestMakeURLAbs_NoHeader(t *testing.T) {
+	req := http.Request{}
+	req.Host = "www.example.com"
+	req.URL = &url.URL{}
+	NewVerifierManager(nil, "default-scheme", -1).makeURLAbs(&req)
+	assert.Equal(t, req.Host, req.URL.Host)
+	assert.Equal(t, "default-scheme", req.URL.Scheme)
+}
+
+func TestMakeURLAbs_WithForwardedHeader(t *testing.T) {
+	req := http.Request{}
+	req.Host = "www.example.com"
+	req.URL = &url.URL{}
+	req.Header = make(http.Header)
+	req.Header.Set("Forwarded", `for="127.0.0.1";proto=https`)
+	NewVerifierManager(nil, "default-scheme", -1).makeURLAbs(&req)
+	assert.Equal(t, req.Host, req.URL.Host)
+	assert.Equal(t, "https", req.URL.Scheme)
+}
+
+func TestMakeURLAbs_WithXForwardedProtoHeader(t *testing.T) {
+	req := http.Request{}
+	req.Host = "www.example.com"
+	req.URL = &url.URL{}
+	req.Header = make(http.Header)
+	req.Header.Set("X-Forwarded-Proto", `https`)
+	NewVerifierManager(nil, "default-scheme", -1).makeURLAbs(&req)
+	assert.Equal(t, req.Host, req.URL.Host)
+	assert.Equal(t, "https", req.URL.Scheme)
+}
+
+func TestCollectRequestParameters(t *testing.T) {
+	// example from TestCollectParameters
+	values := url.Values{}
+	values.Add("c2", "")
+	values.Add("plus", "2 q")
+	req, err := http.NewRequest("POST", "/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b", strings.NewReader(values.Encode()))
+	assert.NoError(t, err)
+	req.Header.Set(contentType, formContentType)
+	req.Header.Set(authorizationHeaderParam, `OAuth realm="Example", oauth_consumer_key="9djdj82h48djs9d2", oauth_token="kkk9d7dh3k39sjv7", oauth_signature_method="HMAC-SHA1", oauth_timestamp="137131201", oauth_nonce="7d8f3e4a", oauth_signature="djosJKDKJSD8743243%2Fjdk33klY%3D"`)
+
+	params, signature, err := collectRequestParameters(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{
+		"b5":                     "=%3D",
+		"a3":                     "a",
+		"c@":                     "",
+		"a2":                     "r b",
+		"oauth_token":            "kkk9d7dh3k39sjv7",
+		"oauth_consumer_key":     "9djdj82h48djs9d2",
+		"oauth_signature_method": "HMAC-SHA1",
+		"oauth_timestamp":        "137131201",
+		"oauth_nonce":            "7d8f3e4a",
+		"c2":                     "",
+		"plus":                   "2 q",
+	}, params)
+	assert.Equal(t, `djosJKDKJSD8743243/jdk33klY=`, signature)
+}
+
+func TestVerifier_RSA(t *testing.T) {
+	// example from TestCollectParameters
+	values := url.Values{}
+	values.Add("c2", "")
+	values.Add("plus", "2 q") // duplicate keys not supported, a3 -> plus
+	req, err := http.NewRequest("POST", "http://127.0.0.1:50428/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b", strings.NewReader(values.Encode()))
+	assert.NoError(t, err)
+	req.Header.Set(contentType, formContentType)
+	req.Header.Set(authorizationHeaderParam, `OAuth oauth_consumer_key="consumer_key", oauth_nonce="6hrVr5eVPa5cWUtnW3sRIMlti2uB0zM43pk9mYIggFY%3D", oauth_signature="Nu%2B7FzqMw%2B18w6%2BzcT45SjWBXWjvf%2FW8adgIpgNahfZGzSExrIA6YRugfngCD97t4ms%2B4Vo2ozPOYHhxq%2BIF3EqoSdno5v53rA9mBvOmNU9XKr7gb92F0MVw%2F6M8MQUhputsUW4L7JixEXHymQUEub82ZC58xHJHklPUNIUtmyuxpzeII7E2K09KLMDp9%2F4ne%2FIm%2FufSoWDCBWn9497SIYZKNGyDAHav9zuXFy8x%2FItwknSpvSGG5zr1j2OyaZz7P5AIHVYPryi1N0Mwu35QHES4pafc0z1Z%2Fgm8PMvcI2BofqdEHbs65okhrE%2BSCxPRqJtc1k4A5LkmWbyp91WqHw%3D%3D", oauth_signature_method="RSA-SHA1", oauth_timestamp="1659497715", oauth_token="", oauth_version="1.0"`)
+
+	err = NewVerifierManager(func(consumerKey, method string, params map[string]string) (Verifier, error) {
+		assert.Equal(t, "consumer_key", consumerKey)
+		assert.Equal(t, "RSA-SHA1", method)
+
+		b, err := base64.StdEncoding.DecodeString(rsaKey)
+		require.NoError(t, err)
+		k, err := x509.ParsePKCS1PrivateKey(b)
+		require.NoError(t, err)
+		return NewRSAVerifier(&k.PublicKey, crypto.SHA1), nil
+	}, "", -1).Verify(req)
+	require.NoError(t, err)
+}
+
+func TestVerifier_HMACSHA1_WithoutOAuthToken(t *testing.T) {
+	// example from TestCollectParameters
+	values := url.Values{}
+	values.Add("c2", "")
+	values.Add("plus", "2 q")
+	req, err := http.NewRequest("POST", "http://127.0.0.1:51060/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b", strings.NewReader(values.Encode()))
+	assert.NoError(t, err)
+	req.Header.Set(contentType, formContentType)
+	req.Header.Set(authorizationHeaderParam, `OAuth oauth_consumer_key="9djdj82h48djs9d2", oauth_nonce="UrmFlgNMjd2UF8sodAzDPqN5AylKo33kxF9gqnd1j7E%3D", oauth_signature="4ZYe7rg2We2jgfv20ZNqlVbCibY%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1659507521", oauth_token="", oauth_version="1.0"`)
+
+	err = NewVerifierManager(func(consumerKey, method string, params map[string]string) (Verifier, error) {
+		assert.Equal(t, "9djdj82h48djs9d2", consumerKey)
+		assert.Equal(t, "HMAC-SHA1", method)
+		return NewHMACVerifier(NewConfig("9djdj82h48djs9d2", "j49sk3j29djd"), ""), nil
+	}, "", -1).Verify(req)
+	require.NoError(t, err)
+}
+
+func TestVerifier_HMACSHA1_WithOAuthToken(t *testing.T) {
+	// example from TestCollectParameters
+	values := url.Values{}
+	values.Add("c2", "")
+	values.Add("plus", "2 q")
+	req, err := http.NewRequest("POST", "/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b", strings.NewReader(values.Encode()))
+	assert.NoError(t, err)
+	req.Header.Set(contentType, formContentType)
+	req.Header.Set(authorizationHeaderParam, `OAuth oauth_consumer_key="9djdj82h48djs9d2", oauth_nonce="FnwtgC3exdLhc2Kspuc9GYPhGzgyQEB1T5tRcfM2FtM%3D", oauth_signature="6F8L5pN4iERKpwRqfuMGA9WesYU%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1659507394", oauth_token="kkk9d7dh3k39sjv7", oauth_version="1.0"`)
+	req.Header.Set("Forwarded", `for="127.0.0.1:51043";proto=http`)
+	req.Host = "127.0.0.1:51043"
+
+	err = NewVerifierManager(func(consumerKey, method string, params map[string]string) (Verifier, error) {
+		assert.Equal(t, "9djdj82h48djs9d2", consumerKey)
+		assert.Equal(t, "HMAC-SHA1", method)
+		return NewHMACVerifier(NewConfig("9djdj82h48djs9d2", "j49sk3j29djd"), "dh893hdasih9"), nil
+	}, "", -1).Verify(req)
+	require.NoError(t, err)
+}
+
+func TestVerifier_TooOld(t *testing.T) {
+	// example from TestCollectParameters
+	values := url.Values{}
+	values.Add("c2", "")
+	values.Add("plus", "2 q")
+	req, err := http.NewRequest("POST", "/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b", strings.NewReader(values.Encode()))
+	assert.NoError(t, err)
+	req.Header.Set(contentType, formContentType)
+	req.Header.Set(authorizationHeaderParam, `OAuth oauth_consumer_key="9djdj82h48djs9d2", oauth_nonce="FnwtgC3exdLhc2Kspuc9GYPhGzgyQEB1T5tRcfM2FtM%3D", oauth_signature="6F8L5pN4iERKpwRqfuMGA9WesYU%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1659507394", oauth_token="kkk9d7dh3k39sjv7", oauth_version="1.0"`)
+	req.Header.Set("Forwarded", `for="127.0.0.1:51043";proto=http`)
+	req.Host = "127.0.0.1:51043"
+
+	err = NewVerifierManager(func(consumerKey, method string, params map[string]string) (Verifier, error) {
+		assert.Equal(t, "9djdj82h48djs9d2", consumerKey)
+		assert.Equal(t, "HMAC-SHA1", method)
+		return NewHMACVerifier(NewConfig("9djdj82h48djs9d2", "j49sk3j29djd"), "dh893hdasih9"), nil
+	}, "", time.Hour).Verify(req)
+	require.Error(t, err)
+}

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -106,6 +107,42 @@ func TestVerifier_RSA(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestVerifier_InvalidRSA(t *testing.T) {
+	// example from TestCollectParameters
+	cases := []string{
+		// invalid signature
+		// first N -> n
+		"nu%2B7FzqMw%2B18w6%2BzcT45SjWBXWjvf%2FW8adgIpgNahfZGzSExrIA6YRugfngCD97t4ms%2B4Vo2ozPOYHhxq%2BIF3EqoSdno5v53rA9mBvOmNU9XKr7gb92F0MVw%2F6M8MQUhputsUW4L7JixEXHymQUEub82ZC58xHJHklPUNIUtmyuxpzeII7E2K09KLMDp9%2F4ne%2FIm%2FufSoWDCBWn9497SIYZKNGyDAHav9zuXFy8x%2FItwknSpvSGG5zr1j2OyaZz7P5AIHVYPryi1N0Mwu35QHES4pafc0z1Z%2Fgm8PMvcI2BofqdEHbs65okhrE%2BSCxPRqJtc1k4A5LkmWbyp91WqHw%3D%3D",
+		// not percent encoded
+		"Nu%%B7FzqMw%2B18w6%2BzcT45SjWBXWjvf%2FW8adgIpgNahfZGzSExrIA6YRugfngCD97t4ms%2B4Vo2ozPOYHhxq%2BIF3EqoSdno5v53rA9mBvOmNU9XKr7gb92F0MVw%2F6M8MQUhputsUW4L7JixEXHymQUEub82ZC58xHJHklPUNIUtmyuxpzeII7E2K09KLMDp9%2F4ne%2FIm%2FufSoWDCBWn9497SIYZKNGyDAHav9zuXFy8x%2FItwknSpvSGG5zr1j2OyaZz7P5AIHVYPryi1N0Mwu35QHES4pafc0z1Z%2Fgm8PMvcI2BofqdEHbs65okhrE%2BSCxPRqJtc1k4A5LkmWbyp91WqHw%3D%3D",
+		// not base64 encoded
+		// last = is replaced
+		"Nu%2B7FzqMw%2B18w6%2BzcT45SjWBXWjvf%2FW8adgIpgNahfZGzSExrIA6YRugfngCD97t4ms%2B4Vo2ozPOYHhxq%2BIF3EqoSdno5v53rA9mBvOmNU9XKr7gb92F0MVw%2F6M8MQUhputsUW4L7JixEXHymQUEub82ZC58xHJHklPUNIUtmyuxpzeII7E2K09KLMDp9%2F4ne%2FIm%2FufSoWDCBWn9497SIYZKNGyDAHav9zuXFy8x%2FItwknSpvSGG5zr1j2OyaZz7P5AIHVYPryi1N0Mwu35QHES4pafc0z1Z%2Fgm8PMvcI2BofqdEHbs65okhrE%2BSCxPRqJtc1k4A5LkmWbyp91WqHw%3D%3A",
+	}
+	for _, signature := range cases {
+		values := url.Values{}
+		values.Add("c2", "")
+		values.Add("plus", "2 q") // duplicate keys not supported, a3 -> plus
+		req, err := http.NewRequest("POST", "http://127.0.0.1:50428/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b", strings.NewReader(values.Encode()))
+		assert.NoError(t, err)
+		req.Header.Set(contentType, formContentType)
+		header := `OAuth oauth_consumer_key="consumer_key", oauth_nonce="6hrVr5eVPa5cWUtnW3sRIMlti2uB0zM43pk9mYIggFY%3D", oauth_signature="` + signature + `", oauth_signature_method="RSA-SHA1", oauth_timestamp="1659497715", oauth_token="", oauth_version="1.0"`
+		req.Header.Set(authorizationHeaderParam, header)
+
+		err = NewVerifierManager(func(consumerKey, method string, params map[string]string) (Verifier, error) {
+			assert.Equal(t, "consumer_key", consumerKey)
+			assert.Equal(t, "RSA-SHA1", method)
+
+			b, err := base64.StdEncoding.DecodeString(rsaKey)
+			require.NoError(t, err)
+			k, err := x509.ParsePKCS1PrivateKey(b)
+			require.NoError(t, err)
+			return NewRSAVerifier(&k.PublicKey, crypto.SHA1), nil
+		}, "", -1).Verify(req)
+		require.Error(t, err)
+	}
+}
+
 func TestVerifier_HMACSHA1_WithoutOAuthToken(t *testing.T) {
 	// example from TestCollectParameters
 	values := url.Values{}
@@ -144,6 +181,24 @@ func TestVerifier_HMACSHA1_WithOAuthToken(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestVerifier_InvalidHMACSHA1(t *testing.T) {
+	// example from TestCollectParameters
+	values := url.Values{}
+	values.Add("c2", "")
+	values.Add("plus", "2 q")
+	req, err := http.NewRequest("POST", "http://127.0.0.1:51060/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b", strings.NewReader(values.Encode()))
+	assert.NoError(t, err)
+	req.Header.Set(contentType, formContentType)
+	req.Header.Set(authorizationHeaderParam, `OAuth oauth_consumer_key="9djdj82h48djs9d2", oauth_nonce="UrmFlgNMjd2UF8sodAzDPqN5AylKo33kxF9gqnd1j7E%3D", oauth_signature="3ZYe7rg2We2jgfv20ZNqlVbCibY%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1659507521", oauth_token="", oauth_version="1.0"`)
+
+	err = NewVerifierManager(func(consumerKey, method string, params map[string]string) (Verifier, error) {
+		assert.Equal(t, "9djdj82h48djs9d2", consumerKey)
+		assert.Equal(t, "HMAC-SHA1", method)
+		return NewHMACVerifier(NewConfig("9djdj82h48djs9d2", "j49sk3j29djd"), ""), nil
+	}, "", -1).Verify(req)
+	require.Error(t, err)
+}
+
 func TestVerifier_TooOld(t *testing.T) {
 	// example from TestCollectParameters
 	values := url.Values{}
@@ -161,5 +216,23 @@ func TestVerifier_TooOld(t *testing.T) {
 		assert.Equal(t, "HMAC-SHA1", method)
 		return NewHMACVerifier(NewConfig("9djdj82h48djs9d2", "j49sk3j29djd"), "dh893hdasih9"), nil
 	}, "", time.Hour).Verify(req)
+	require.Error(t, err)
+}
+
+func TestVerifier_RejectedByGetVerifier(t *testing.T) {
+	// example from TestCollectParameters
+	values := url.Values{}
+	values.Add("c2", "")
+	values.Add("plus", "2 q")
+	req, err := http.NewRequest("POST", "/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b", strings.NewReader(values.Encode()))
+	assert.NoError(t, err)
+	req.Header.Set(contentType, formContentType)
+	req.Header.Set(authorizationHeaderParam, `OAuth oauth_consumer_key="9djdj82h48djs9d2", oauth_nonce="FnwtgC3exdLhc2Kspuc9GYPhGzgyQEB1T5tRcfM2FtM%3D", oauth_signature="6F8L5pN4iERKpwRqfuMGA9WesYU%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1659507394", oauth_token="kkk9d7dh3k39sjv7", oauth_version="1.0"`)
+	req.Header.Set("Forwarded", `for="127.0.0.1:51043";proto=http`)
+	req.Host = "127.0.0.1:51043"
+
+	err = NewVerifierManager(func(consumerKey, method string, params map[string]string) (Verifier, error) {
+		return nil, fmt.Errorf("fail to get verifier")
+	}, "", -1).Verify(req)
 	require.Error(t, err)
 }


### PR DESCRIPTION
An implementation that can verify the OAuth1 signature in request.  

Most Japanese SNS follow Google OpenSocial gadgets.io spec, require resource server to verify OAuth1 signature sent by gadgets.io.makeRequest().

I can add some examples in readme.

Co-authored-by: https://github.com/fieliapm