### PR TITLE
Use a centrally managed GitHub Workflow for go tests

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,3 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  pull-request-branch-name:
-    separator: "-"
-  open-pull-requests-limit: 3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,25 +1,6 @@
 name: test
 on:
   push:
-    branches:
-      - main
-  pull_request:
 jobs:
-  build:
-    name: go
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go: ['1.18', '1.19']
-    steps:
-      - name: setup
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{matrix.go}}
-
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - name: test
-        run: make
+  go:
+    uses: dghubble/.github/.github/workflows/golang-library.yaml@main

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# OAuth1 [![GoDoc](https://pkg.go.dev/badge/github.com/dghubble/oauth1.svg)](https://pkg.go.dev/github.com/dghubble/oauth1) [![Workflow](https://github.com/dghubble/oauth1/actions/workflows/test.yaml/badge.svg)](https://github.com/dghubble/oauth1/actions/workflows/test.yaml?query=branch%3Amain) [![Sponsors](https://img.shields.io/github/sponsors/dghubble?logo=github)](https://github.com/sponsors/dghubble) [![Mastodon](https://img.shields.io/badge/follow-news-6364ff?logo=mastodon)](https://fosstodon.org/@typhoon)
+# OAuth1
+[![GoDoc](https://pkg.go.dev/badge/github.com/dghubble/oauth1.svg)](https://pkg.go.dev/github.com/dghubble/oauth1)
+[![Workflow](https://github.com/dghubble/oauth1/actions/workflows/test.yaml/badge.svg)](https://github.com/dghubble/oauth1/actions/workflows/test.yaml?query=branch%3Amain)
+[![Sponsors](https://img.shields.io/github/sponsors/dghubble?logo=github)](https://github.com/sponsors/dghubble)
+[![Mastodon](https://img.shields.io/badge/follow-news-6364ff?logo=mastodon)](https://fosstodon.org/@typhoon)
 
 <img align="right" src="https://storage.googleapis.com/dghubble/oauth1.png">
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dghubble/oauth1
 
-go 1.18
+go 1.19
 
 require github.com/stretchr/testify v1.8.1
 


### PR DESCRIPTION
* Use GitHub Workflow from https://github.com/dghubble/.github
* Test against Go v1.19 and v1.20