### PR TITLE
Fix HMAC-SHA1 key creation.

### DIFF
--- a/signer.go
+++ b/signer.go
@@ -32,7 +32,7 @@ func (s *HMACSigner) Name() string {
 }
 
 func hmacSign(consumerSecret, tokenSecret, message string, algo func() hash.Hash) (string, error) {
-	signingKey := strings.Join([]string{consumerSecret, tokenSecret}, "&")
+	signingKey := strings.Join([]string{PercentEncode(consumerSecret), PercentEncode(tokenSecret)}, "&")
 	mac := hmac.New(algo, []byte(signingKey))
 	mac.Write([]byte(message))
 	signatureBytes := mac.Sum(nil)


### PR DESCRIPTION
Per the OAuth 1.0 spec (https://oauth.net/core/1.0a/#anchor15), the consumer secret and the tokenSecret both need to be parameter-encoded before being concatenated with the "&". This change performs this encoding with PercentEncode().

Without this change, OAuth would fail for services that include special characters in either the Consumer secret or the Request Token secret, but would succeed for services that did not. Specifically, this fix allows this library to be used with the etrade API, which does include special characters in the Request Token secret.