### PR TITLE
Work with `context.Context` & deprecates `io/ioutil`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ func main() {
     path := "https://api.twitter.com/1.1/statuses/home_timeline.json?count=2"
     resp, _ := httpClient.Get(path)
     defer resp.Body.Close()
-    body, _ := ioutil.ReadAll(resp.Body)
+    body, _ := io.ReadAll(resp.Body)
     fmt.Printf("Raw Response Body:\n%v\n", string(body))
 }
 ```

--- a/auther.go
+++ b/auther.go
@@ -3,7 +3,7 @@ package oauth1
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -207,7 +207,7 @@ func collectParameters(req *http.Request, oauthParams map[string]string) (map[st
 	}
 	if req.Body != nil && req.Header.Get(contentType) == formContentType {
 		// reads data to a []byte, draining req.Body
-		b, err := ioutil.ReadAll(req.Body)
+		b, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -220,7 +220,7 @@ func collectParameters(req *http.Request, oauthParams map[string]string) (map[st
 			params[key] = value[0]
 		}
 		// reinitialize Body with ReadCloser over the []byte
-		req.Body = ioutil.NopCloser(bytes.NewReader(b))
+		req.Body = io.NopCloser(bytes.NewReader(b))
 	}
 	for key, value := range oauthParams {
 		// according to 3.4.1.3.1. the realm parameter is excluded

--- a/config.go
+++ b/config.go
@@ -65,8 +65,8 @@ func NewClient(ctx context.Context, config *Config, token *Token) *http.Client {
 // oauth_callback_confirmed is true. Returns the request token and secret
 // (temporary credentials).
 // See RFC 5849 2.1 Temporary Credentials.
-func (c *Config) RequestToken() (requestToken, requestSecret string, err error) {
-	req, err := http.NewRequest("POST", c.Endpoint.RequestTokenURL, nil)
+func (c *Config) RequestToken(ctx context.Context) (requestToken, requestSecret string, err error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", c.Endpoint.RequestTokenURL, nil)
 	if err != nil {
 		return "", "", err
 	}
@@ -144,8 +144,8 @@ func ParseAuthorizationCallback(req *http.Request) (requestToken, verifier strin
 // Endpoint AccessTokenURL. Returns the access token and secret (token
 // credentials).
 // See RFC 5849 2.3 Token Credentials.
-func (c *Config) AccessToken(requestToken, requestSecret, verifier string) (accessToken, accessSecret string, err error) {
-	req, err := http.NewRequest("POST", c.Endpoint.AccessTokenURL, nil)
+func (c *Config) AccessToken(ctx context.Context, requestToken, requestSecret, verifier string) (accessToken, accessSecret string, err error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", c.Endpoint.AccessTokenURL, nil)
 	if err != nil {
 		return "", "", err
 	}

--- a/config.go
+++ b/config.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -81,7 +81,7 @@ func (c *Config) RequestToken(ctx context.Context) (requestToken, requestSecret 
 	// when err is nil, resp contains a non-nil resp.Body which must be closed
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", fmt.Errorf("oauth1: error reading Body: %v", err)
 	}
@@ -160,7 +160,7 @@ func (c *Config) AccessToken(ctx context.Context, requestToken, requestSecret, v
 	// when err is nil, resp contains a non-nil resp.Body which must be closed
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", "", fmt.Errorf("oauth1: error reading Body: %v", err)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -106,7 +106,7 @@ func TestConfigRequestToken(t *testing.T) {
 			RequestTokenURL: server.URL,
 		},
 	}
-	requestToken, requestSecret, err := config.RequestToken()
+	requestToken, requestSecret, err := config.RequestToken(context.TODO())
 	assert.Nil(t, err)
 	assert.Equal(t, expectedToken, requestToken)
 	assert.Equal(t, expectedSecret, requestSecret)
@@ -118,7 +118,7 @@ func TestConfigRequestToken_InvalidRequestTokenURL(t *testing.T) {
 			RequestTokenURL: "http://wrong.com/oauth/request_token",
 		},
 	}
-	requestToken, requestSecret, err := config.RequestToken()
+	requestToken, requestSecret, err := config.RequestToken(context.TODO())
 	assert.NotNil(t, err)
 	assert.Equal(t, "", requestToken)
 	assert.Equal(t, "", requestSecret)
@@ -139,7 +139,7 @@ func TestConfigRequestToken_CallbackNotConfirmed(t *testing.T) {
 			RequestTokenURL: server.URL,
 		},
 	}
-	requestToken, requestSecret, err := config.RequestToken()
+	requestToken, requestSecret, err := config.RequestToken(context.TODO())
 	if assert.Error(t, err) {
 		assert.Equal(t, "oauth1: oauth_callback_confirmed was not true", err.Error())
 	}
@@ -156,7 +156,7 @@ func TestConfigRequestToken_CannotParseBody(t *testing.T) {
 			RequestTokenURL: server.URL,
 		},
 	}
-	requestToken, requestSecret, err := config.RequestToken()
+	requestToken, requestSecret, err := config.RequestToken(context.TODO())
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "invalid URL escape")
 	}
@@ -176,7 +176,7 @@ func TestConfigRequestToken_MissingTokenOrSecret(t *testing.T) {
 			RequestTokenURL: server.URL,
 		},
 	}
-	requestToken, requestSecret, err := config.RequestToken()
+	requestToken, requestSecret, err := config.RequestToken(context.TODO())
 	if assert.Error(t, err) {
 		assert.Equal(t, "oauth1: Response missing oauth_token or oauth_token_secret", err.Error())
 	}
@@ -226,7 +226,7 @@ func TestConfigAccessToken(t *testing.T) {
 			AccessTokenURL: server.URL,
 		},
 	}
-	accessToken, accessSecret, err := config.AccessToken("request_token", "request_secret", expectedVerifier)
+	accessToken, accessSecret, err := config.AccessToken(context.TODO(), "request_token", "request_secret", expectedVerifier)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedToken, accessToken)
 	assert.Equal(t, expectedSecret, accessSecret)
@@ -238,7 +238,7 @@ func TestConfigAccessToken_InvalidAccessTokenURL(t *testing.T) {
 			AccessTokenURL: "http://wrong.com/oauth/access_token",
 		},
 	}
-	accessToken, accessSecret, err := config.AccessToken("any_token", "any_secret", "any_verifier")
+	accessToken, accessSecret, err := config.AccessToken(context.TODO(), "any_token", "any_secret", "any_verifier")
 	assert.NotNil(t, err)
 	assert.Equal(t, "", accessToken)
 	assert.Equal(t, "", accessSecret)
@@ -253,7 +253,7 @@ func TestConfigAccessToken_CannotParseBody(t *testing.T) {
 			AccessTokenURL: server.URL,
 		},
 	}
-	accessToken, accessSecret, err := config.AccessToken("any_token", "any_secret", "any_verifier")
+	accessToken, accessSecret, err := config.AccessToken(context.TODO(), "any_token", "any_secret", "any_verifier")
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "invalid URL escape")
 	}
@@ -272,7 +272,7 @@ func TestConfigAccessToken_MissingTokenOrSecret(t *testing.T) {
 			AccessTokenURL: server.URL,
 		},
 	}
-	accessToken, accessSecret, err := config.AccessToken("request_token", "request_secret", expectedVerifier)
+	accessToken, accessSecret, err := config.AccessToken(context.TODO(), "request_token", "request_secret", expectedVerifier)
 	if assert.Error(t, err) {
 		assert.Equal(t, "oauth1: Response missing oauth_token or oauth_token_secret", err.Error())
 	}

--- a/doc.go
+++ b/doc.go
@@ -88,7 +88,7 @@ Use an access Token to make authorized requests on behalf of a user.
 	    path := "https://api.twitter.com/1.1/statuses/home_timeline.json?count=2"
 	    resp, _ := httpClient.Get(path)
 	    defer resp.Body.Close()
-	    body, _ := ioutil.ReadAll(resp.Body)
+	    body, _ := io.ReadAll(resp.Body)
 	    fmt.Printf("Raw Response Body:\n%v\n", string(body))
 	}
 

--- a/examples/tumblr-request.go
+++ b/examples/tumblr-request.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/dghubble/oauth1"
@@ -29,7 +29,7 @@ func main() {
 	path := "https://api.tumblr.com/v2/user/info"
 	resp, _ := httpClient.Get(path)
 	defer resp.Body.Close()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	fmt.Printf("Raw Response Body:\n%v\n", string(body))
 
 	// note: Tumblr requires OAuth signed requests for particular endpoints,

--- a/examples/twitter-request.go
+++ b/examples/twitter-request.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/dghubble/go-twitter/twitter"
@@ -29,7 +29,7 @@ func main() {
 	path := "https://api.twitter.com/1.1/statuses/home_timeline.json?count=2"
 	resp, _ := httpClient.Get(path)
 	defer resp.Body.Close()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	fmt.Printf("Raw Response Body:\n%v\n", string(body))
 
 	// Nicer: Pass OAuth1 client to go-twitter API

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dghubble/oauth1
+module github.com/cappfm/go-oauth1
 
 go 1.19
 


### PR DESCRIPTION
## What changed?

⚠️ This PR would break retro-compatibility. I don't know if it is acceptable and will leave it to the appreciation of the reviewer.

1. `Config.RequestToken()` and `Config.AccessToken()` now requires a `context.Context`
2. Deprecates `io/ioutil` and replaces by `io`